### PR TITLE
Añadir versión de nodo y gateway con placa TTGO ESP32 v1

### DIFF
--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/CHANGELOG.md
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/CHANGELOG.md
@@ -1,0 +1,124 @@
+# Single Channel LoRaWAN Gateway
+
+Version 4.0.7, July 22, 2017  
+Author: M. Westenberg (mw12554@hotmail.com)  
+Copyright: M. Westenberg (mw12554@hotmail.com)  
+
+All rights reserved. This program and the accompanying materials are made available under the terms 
+of the MIT License which accompanies this distribution, and is available at
+https://opensource.org/licenses/mit-license.php  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Maintained by Maarten Westenberg (mw12554@hotmail.com)
+
+
+
+# Release Notes
+
+New features in version 4.0.9 (August 11, 2017)
+
+- This release contains updates for memory leaks in several Gateway files
+- Also changes in OLED functions
+
+New features in version 4.0.8 (August 05, 2017)
+
+- This release updates for memory leaks in NTP routines (see ESP-sc-gway.h file for NTP_INTR
+- OLED support contributed by Dorijan Morelj (based on Adreas Spies' release)
+
+New features in version 4.0.7 (July 22, 2017)
+
+- This release contains merely updates to memory leaks and patches to avoid chip resets etc.
+- The webinterface allows the user to see more parameters and has buttons to set/reset these parameters.
+- By setting debug >=2, the webinterface will display more information.
+- The gateway allows OTA (Over the Air) update. Please have an Apple "Bonjour" somewhere on your network 
+(included in iTunes) and you will see the network port in the "Port" section of your IDE.
+
+New features in version 4.0.4 (June 24, 2017):
+
+- Review of the _wwwServer.ino file. Repaired some of the bugs causing crashes of the webserver.
+- Updated the README.md file with more cofniguration information
+
+New features in version 4.0.3 (June 22, 2017):
+
+- Added CMAC functions so that the sensor functions work as expected over TTN
+- Webserver prints a page in chunks now, so that memory usage is lower and more heap is left over for variables
+- Webserver does refresh every 60 seconds
+- Implemented suggested change of M. for answer to PKT_PULL_RESP
+- Updated README.md to correctly displa all headers
+- Several small bug fixes
+
+New features in version 4.0.0 (January 26, 2017)):
+
+- Implement both CAD (Channel Activity Detection) and HOP functions (HOP being experimental)
+- Message history visible in web interface
+- Repaired the WWW server memory leak (due to String assignments)
+- Still works on one interrupt line (GPIO15), or can be configured to work with 2 interrupt lines for dio0 and dio1
+  for two or more interrupt lines (better performance for automatic SF setting?)
+- Webserver with debug level 3 and level 4 (for interrupt testing).
+  dynamic setting thorugh the web interface. Level 3 and 4 will show more info
+  on sf, rssi, interrupt flags etc.
+- Tested on Arduino IDE 1.18.0
+- See http://things4u.github.io for documentation
+
+New features in version 3.3.0 (January 1, 2017)):
+
+- Redesign of the Webserver interface
+- Use of the SPIFFS filesystem to store SSID, Frequency, Spreading Factor and Framecounter to survice reboots and resets of the ESP8266
+- Possibility to set the Spreading Factor dynamically throug the web interface
+- Possibility to set the Frequency in the web interface
+- Reset the Framecounter in te webinterface
+
+New features in version 3.2.2 (December 29, 2016)):
+
+- Repair the situation where WIFIMANAGER was set to 0 in the ESP-sc-gway.h file. The sketch would not compile which is now repaired
+- The compiler would issue a set of warnings related to the ssid and passw setting in the ESP-sc-geway.h file. Compiler was complaining (and it should) because char* were statically initialised and modified in the code.
+
+New features in version 3.2.1 (December 20, 2016)):
+
+- Repair the status messages to the server. All seconds, minutes, hours etc. are now reported in 2 digits. The year is reported in 4 digits.
+
+New features in version 3.2.0 (December 08, 2016)):
+
+- Several bugfixes
+
+New features in version 3.1 (September 29, 2016)):
+
+- In the ESP-sc-gway.h it is possible to set the gateway as sensor node as well. Just set the DevAddr and AppSKey in the _sensor.ino file and be able to forward any sensor or other values to the server as if they were coming from a LoRa node.
+- If the #define _STRICT_1CH is set (to 1) then the system will be able to send downlink messages to LoRa nodes that are strict 1-channel devices (all frequencies but frequency 0 are disabled and Spreading Factor (SF) is fixed to one value).
+- Code clean-up. The code has been made smaller in the area of loraWait() functions and where the radio is initiated for receiving of transmitting messages.
+- Several small bug fixes
+- Licensing, the license has been changed to MIT
+
+New features in version 3.0 (September 27, 2016):
+
+- WiFiManager support
+- Limited SPIFF (filesystem) support for persistent data storage
+- Added functions to webserver. Webserver port now 80 by default (!)
+
+Other
+
+- Supports ABP nodes (TeensyLC and Arduino Pro-mini)
+- Supports OTAA functions on TeensyLC and Arduino Pro-Mini (not all of them) for SF7 and SF8.
+- Supports SF7, SF8. SF7 is tested for downstream communication
+- Listens on configurable frequency and spreading factor
+- Send status updates to server (keepalive)
+- PULL_DATA messages to server
+- It can forward messages to two servers at the same time (and read from them as well)
+- DNS support for server lookup
+- NTP Support for time sync with internet time servers
+- Webserver support (default port 8080)
+- .h header file for configuration
+
+Not (yet) supported:
+
+- SF7BW250 modulation
+- FSK modulation
+- RX2 timeframe messages at frequency 869,525 MHz are not (yet) supported.
+- SF9-SF12 downlink messaging available but needs more testing
+
+
+# License
+
+The source files of the gateway sketch in this repository is made available under the MIT
+license. The libraries included in this repository are included for convenience only and all have their own license, and are not part of the ESP 1ch gateway code.

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/ESP-sc-gway.h
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/ESP-sc-gway.h
@@ -1,0 +1,261 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// Based on work done by Thomas Telkamp for Raspberry PI 1ch gateway and many others.
+// Contibutions of Dorijan Morelj and Andreas Spies for OLED support.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains a number of compile-time settings that can be set on (=1) or off (=0)
+// The disadvantage of compile time is minor compared to the memory gain of not having
+// too much code compiled and loaded on your ESP8266.
+//
+// ----------------------------------------------------------------------------------------
+
+// For Heltec ESP32 based WIFI_LoRa_32 boards (and may-be others as well)
+// REMOVE for ESP8266 builds
+#define ESP32BUILD  1
+
+#ifdef ESP32BUILD
+#define VERSION "V.5.0.2.H+; 171128a nOLED, 15/10"
+#else
+#define VERSION "V.5.0.2.H; 171118a nOLED, 15/10"
+#endif
+
+// This value of DEBUG determines whether some parts of code get compiled.
+// Also this is the initial value of debug parameter. 
+// The value can be changed using the admin webserver
+// For operational use, set initial DEBUG vaulue 0
+#define DEBUG 0
+
+// Debug message will be put on Serial is this one is set.
+// If set to 0, not USB Serial prints are done
+// Set to 1 it will prin all user level messages (with correct debug set)
+// If set to 2 it will also print interrupt messages (not recommended)
+#define DUSB 1
+
+// The spreading factor is the most important parameter to set for a single channel
+// gateway. It specifies the speed/datarate in which the gateway and node communicate.
+// As the name says, in principle the single channel gateway listens to one channel/frequency
+// and to one spreading factor only.
+// This parameters contains the default value of SF, the actual version can be set with
+// the webserver and it will be stored in SPIFF
+// NOTE: The frequency is set in the loraModem.h file and is default 868.100000 MHz.
+#define _SPREADING SF7
+
+// Channel Activity Detection
+// This function will scan for valid LoRa headers and determine the Spreading 
+// factor accordingly. If set to 1 we will use this function which means the 
+// 1-channel gateway will become even more versatile. If set to 0 we will use the
+// continuous listen mode.
+// Using this function means that we HAVE to use more dio pins on the RFM95/sx1276
+// device and also connect enable dio1 to detect this state. 
+#define _CAD 1
+
+// Definitions for the admin webserver.
+// A_SERVER determines whether or not the admin webpage is included in the sketch.
+// Normally, leave it in!
+#define A_SERVER 1        // Define local WebServer only if this define is set
+#define A_REFRESH 1				// Will the webserver refresh or not?
+#define A_SERVERPORT 80			// local webserver port
+#define A_MAXBUFSIZE 192		// Must be larger than 128, but small enough to work
+
+// Definitions for over the air updates. At the moment we support OTA with IDE
+// Make sure that tou have installed Python version 2.7 and have Bonjour in your network.
+// Bonjour is included in iTunes (which is free) and OTA is recommended to install 
+// the firmware on your router witout having to be really close to the gateway and 
+// connect with USB.
+//
+#ifdef ESP32BUILD
+// Not available (yet) for ESP32
+#define A_OTA 0
+#else
+#define A_OTA 0
+#endif
+
+// We support two pin-out configurations out-of-the-box: HALLARD and COMPRESULT.
+// If you use one of these two, just set the parameter to the right value.
+// If your pin definitions are different, update the loraModem.h file to reflect these settings.
+//	1: HALLARD
+//	2: COMRESULT pin out
+//	3: For Heltec ESP32 based WIFI_LoRa_32 board
+//  4: Other, define your own in loraModem.h
+#define _PIN_OUT 3
+
+// Gather statistics on sensor and Wifi status
+// 0= No statistics
+// 1= Keep track of messages statistics, number determined by MAX_STAT
+// 2= See 1 + Keep track of messages received PER each SF
+#define STATISTICS 2
+
+// Maximum number of statistics records gathered. 20 is a good maximum (memory intensive)
+#define MAX_STAT 20
+
+// Single channel gateways if they behave strict should only use one frequency 
+// channel and one spreading factor. However, the TTN backend replies on RX2 
+// timeslot for spreading factors SF9-SF12. 
+// Also, the server will respond with SF12 in the RX2 timeslot.
+// If the 1ch gateway is working in and for nodes that ONLY transmit and receive on the set
+// and agreed frequency and spreading factor. make sure to set STRICT to 1.
+// In this case, the frequency and spreading factor for downlink messages is adapted by this
+// gateway
+// NOTE: If your node has only one frequency enabled and one SF, you must set this to 1
+//		in order to receive downlink messages
+// NOTE: In all other cases, value 0 works for most gateways with CAD enabled
+#define _STRICT_1CH	1
+
+// Allows configuration through WifiManager AP setup. Must be 0 or 1					
+#ifdef ESP32BUILD
+// Not available (yet) for ESP32
+#define WIFIMANAGER 0
+#else
+#define WIFIMANAGER 0
+#endif
+
+// Define the name of the accesspoint if the gateway is in accesspoint mode (is
+// getting WiFi SSID and password using WiFiManager)
+#ifdef ESP32BUILD
+#define AP_NAME "ESP32-Gway-Things4U"
+#else
+#define AP_NAME "ESP8266-Gway-Things4U"
+#endif
+#define AP_PASSWD "LoRa94784732"
+
+
+// Defines whether the gateway will also report sensor/status value on MQTT
+// after all, a gateway can be a node to the system as well
+// Set its LoRa address and key below in this file
+// See spec. para 4.3.2
+#define GATEWAYNODE 0
+#define _CHECK_MIC 0
+
+// This section defines whether we use the gateway as a repeater
+// For his, we use another output channle as the channel (default==0) we are 
+// receiving the messages on.
+#define REPEATER 0
+
+// Will we use Mutex or not?
+// +SPI is input for SPI, SPO is output for SPI
+#define MUTEX 1
+#define MUTEX_SPI 0
+#define MUTEX_SPO 0
+// Protect the interrupt module
+#define MUTEX_INT 0
+
+// Define whether we want to manage the gateway over UDP (next to management 
+// thru webinterface).
+// This will allow us to send messages over the UDP connection to manage the gateway 
+// and its parameters. Sometimes the gateway is not accesible from remote, 
+// in this case we would allow it to use the SERVER UDP connection to receive 
+// messages as well.
+// NOTE: Be aware that these messages are NOT LoRa and NOT LoRa Gateway spec compliant.
+//	However that should not interfere with regular gateway operation but instead offer 
+//	functions to set/reset certain parameters from remote.
+#define GATEWAYMGT 0
+
+// Name of he configfile in SPIFFs	filesystem
+// In this file we store the configuration and other relevant info that should
+// survive a reboot of the gateway		
+#define CONFIGFILE "/gwayConfig.txt"
+
+// Set the Server Settings (IMPORTANT)
+#define _LOCUDPPORT 1700					// UDP port of gateway! Often 1700 or 1701 is used for upstream comms
+
+// Timing
+#define _MSG_INTERVAL 15
+#define _PULL_INTERVAL 55					// PULL_DATA messages to server to get downstream in milliseconds
+#define _STAT_INTERVAL 120					// Send a 'stat' message to server
+#define _NTP_INTERVAL 3600					// How often do we want time NTP synchronization
+#define _WWW_INTERVAL	60					// Number of seconds before we refresh the WWW page
+
+// MQTT definitions, these settings should be standard for TTN
+// and need not changing
+#define _TTNPORT 1700						// Standard port for TTN
+#define _TTNSERVER "router.eu.thethings.network"
+
+// If you have a second back-end server defined such as Semtech or loriot.io
+// your can define _THINGPORT and _THINGSERVER with your own value.
+// If not, make sure that you do not defined these, which will save CPU time
+// Port is UDP port in this program
+//
+// Default for testing: Switch off
+//#define _THINGPORT 1700					// dash.westenberg.org:8057
+//#define _THINGSERVER "yourServer.com"		// Server URL of the LoRa-udp.js handler
+
+// Gateway Ident definitions
+#define _DESCRIPTION "My ESP32 Gateway 868.1MHz SF7"
+#define _EMAIL "your@email.com"
+#define _PLATFORM "ESP32"
+#define _LAT 0.00
+#define _LON -0.00
+#define _ALT 0
+
+// ntp
+#define NTP_TIMESERVER "es.pool.ntp.org"	// Country and region specific
+#define NTP_TIMEZONES	1					// How far is our Timezone from UTC (excl daylight saving/summer time)
+#define SECS_PER_HOUR	3600
+#define NTP_INTR 0							// Do NTP processing with interrupts or in loop();
+
+#if GATEWAYNODE==1
+#define _DEVADDR { 0x26, 0x00, 0x00 0x00 }
+#define _APPSKEY { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+#define _NWKSKEY { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+#define _SENSOR_INTERVAL 300
+#endif
+
+// Define the correct radio type that you are using
+#define CFG_sx1276_radio		
+//#define CFG_sx1272_radio
+
+// Serial Port speed
+#define _BAUDRATE 115200					// Works for debug messages to serial momitor
+
+// if OLED Display is connected to i2c
+#define OLED 1								// Make define 1 on line if you have an OLED display connected
+#define OLED_SCL 15							// GPIO5 / D1
+#define OLED_SDA 4							// GPIO4 / D2
+#define OLED_ADDR 0x3C						// Default 0x3C for 0.9", for 1.3" it is 0x78
+
+// Wifi definitions
+// WPA is an array with SSID and password records. Set WPA size to number of entries in array
+// When using the WiFiManager, we will overwrite the first entry with the 
+// accesspoint we last connected to with WifiManager
+// NOTE: Structure needs at least one (empty) entry.
+//		So WPASIZE must be >= 1
+struct wpas {
+	char login[32];							// Maximum Buffer Size (and allocated memory)
+	char passw[64];
+};
+
+// Please fill in at least ONE SSID and password from your own WiFI network
+// below. This is needed to get the gateway working
+// Note: DO NOT use the first and the last line of the stucture, these should be empty strings and
+//	the first line in te struct is reserved for WifiManager.
+//
+#if 1
+wpas wpa[] = {
+	{ "" , "" },							// Reserved for WiFi Manager
+    { "SSID1", "PASSWD1" },
+	{ "SSID2", "PASSWD2" }
+};
+#else
+// Place outside version control to avoid the risk of commiting it to github ;-)
+#include "wpa.h"
+#endif
+
+// For asserting and testing the following defines are used.
+//
+#if !defined(CFG_noassert)
+#define ASSERT(cond) if(!(cond)) gway_failed(__FILE__, __LINE__)
+#else
+#define ASSERT(cond) /**/
+#endif
+
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/ESP-sc-gway.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/ESP-sc-gway.ino
@@ -1,0 +1,1567 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1-ch gateway
+//	and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// The protocols and specifications used for this 1ch gateway: 
+// 1. LoRA Specification version V1.0 and V1.1 for Gateway-Node communication
+//	
+// 2. Semtech Basic communication protocol between Lora gateway and server version 3.0.0
+//	https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT
+//
+// Notes: 
+// - Once call gethostbyname() to get IP for services, after that only use IP
+//	 addresses (too many gethost name makes the ESP unstable)
+// - Only call yield() in main stream (not for background NTP sync). 
+//
+// ----------------------------------------------------------------------------------------
+
+//
+
+#include "ESP-sc-gway.h"					
+// This file contains configuration of GWay
+
+#include <Esp.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <cstdlib>
+#include <sys/time.h>
+#include <cstring>
+#include <SPI.h>
+#include <TimeLib.h>							// http://playground.arduino.cc/code/time
+#ifdef ESP32BUILD
+#include "esp_wifi.h"
+#include "WiFi.h"
+#include "SPIFFS.h"
+#else
+#include <ESP8266WiFi.h>
+#include <DNSServer.h> 							// Local DNSserver
+#endif
+#include "FS.h"
+#include <WiFiUdp.h>
+#include <pins_arduino.h>
+#include <ArduinoJson.h>
+#include <SimpleTimer.h>
+#include <gBase64.h>							// https://github.com/adamvr/arduino-base64 (changed the name)
+#ifndef ESP32BUILD
+#include <ESP8266mDNS.h>
+
+extern "C" {
+#include "user_interface.h"
+#include "lwip/err.h"
+#include "lwip/dns.h"
+#include "c_types.h"
+}
+#endif
+
+#if MUTEX_LIB==1
+#include <mutex.h>								// See lib directory
+#endif
+
+#include "loraModem.h"
+#include "loraFiles.h"
+
+
+#if WIFIMANAGER>0
+#include <WiFiManager.h>						// Library for ESP WiFi config through an AP
+#endif
+
+#if A_OTA==1
+#include <ESP8266httpUpdate.h>
+#include <ArduinoOTA.h>
+#endif
+
+#if A_SERVER==1
+#include <ESP8266WebServer.h>
+#endif 
+
+#if GATEWAYNODE==1
+#include "AES-128_V10.h"
+#endif
+
+#if OLED==1
+#include "SSD1306.h"
+SSD1306  display (OLED_ADDR, OLED_SDA, OLED_SCL);// i2c ADDR & SDA, SCL on wemos
+#endif
+
+int debug = 1;									// Debug level! 0 is no msgs, 1 normal, 2 extensive
+
+// You can switch webserver off if not necessary but probably better to leave it in.
+#if A_SERVER==1
+
+#ifdef ESP32BUILD
+#include <WiFiClient.h>
+#include <WebServer.h>
+#include <ESPmDNS.h>
+WebServer server (A_SERVERPORT);
+#else
+#include <Streaming.h>          				// http://arduiniana.org/libraries/streaming/
+ESP8266WebServer server (A_SERVERPORT);
+#endif //ESP32BUILD
+
+#endif //A_SERVER
+
+using namespace std;
+
+byte currentMode = 0x81;
+
+//char b64[256];
+bool sx1272 = true;								// Actually we use sx1276/RFM95
+
+uint32_t cp_nb_rx_rcv;
+uint32_t cp_nb_rx_ok;
+uint32_t cp_nb_rx_bad;
+uint32_t cp_nb_rx_nocrc;
+uint32_t cp_up_pkt_fwd;
+
+uint8_t MAC_array[6];
+//char MAC_char[19];
+
+// ----------------------------------------------------------------------------
+//
+// Configure these values only if necessary!
+//
+// ----------------------------------------------------------------------------
+
+// Set spreading factor (SF7 - SF12)
+sf_t sf = _SPREADING;
+sf_t sfi = _SPREADING;				// Initial value of SF
+
+// Set location, description and other configuration parameters
+// Defined in ESP-sc_gway.h
+//
+float lat = _LAT;						// Configuration specific info...
+float lon = _LON;
+int   alt = _ALT;
+char platform[24] = _PLATFORM; 				// platform definition
+char email[40] = _EMAIL;    				// used for contact email
+char description[64] = _DESCRIPTION;				// used for free form description 
+
+// define servers
+
+IPAddress ntpServer;							// IP address of NTP_TIMESERVER
+IPAddress ttnServer;							// IP Address of thethingsnetwork server
+IPAddress thingServer;
+
+WiFiUDP Udp;
+uint32_t stattime = 0;							// last time we sent a stat message to server
+uint32_t pulltime = 0;							// last time we sent a pull_data request to server
+uint32_t lastTmst = 0;
+#if A_SERVER==1
+uint32_t wwwtime = 0;
+#endif
+#if NTP_INTR==0
+uint32_t ntptimer = 0;
+#endif
+
+SimpleTimer timer; 								// Timer is needed for delayed sending
+
+#define TX_BUFF_SIZE  1024						// Upstream buffer to send to MQTT
+#define RX_BUFF_SIZE  1024						// Downstream received from MQTT
+#define STATUS_SIZE	  512						// Should(!) be enough based on the static text .. was 1024
+
+#if GATEWAYNODE==1
+uint16_t frameCount = 0;							// We write this to SPIFF file
+#endif
+
+// volatile bool inSPI This initial value of mutex is to be free,
+// which means that its value is 1 (!)
+// 
+int inSPI = 1;
+int inSPO = 1;
+int mutexSPI = 1;
+
+//volatile bool inIntr = false;
+int inIntr;
+
+// ----------------------------------------------------------------------------
+// FORWARD DECARATIONS
+// These forward declarations are done since _loraModem.ino is linked by the
+// compiler/linker AFTER the main ESP-sc-gway.ino file. 
+// And espcesially when calling functions with ICACHE_RAM_ATTR the complier 
+// does not want this.
+// ----------------------------------------------------------------------------
+
+void ICACHE_RAM_ATTR Interrupt_0 ();
+void ICACHE_RAM_ATTR Interrupt_1 ();
+
+#if MUTEX==1
+// Forward declarations
+void ICACHE_FLASH_ATTR CreateMutux (int *mutex);
+bool ICACHE_FLASH_ATTR GetMutex (int *mutex);
+void ICACHE_FLASH_ATTR ReleaseMutex (int *mutex);
+#endif
+
+// ----------------------------------------------------------------------------
+// DIE is not use actively in the source code anymore.
+// It is replaced by a Serial.print command so we know that we have a problem
+// somewhere.
+// There are at least 3 other ways to restart the ESP. Pick one if you want.
+// ----------------------------------------------------------------------------
+void die (const char *s) {
+	Serial.println (s);
+	if (debug >= 2) Serial.flush ();
+
+	delay (50);
+	// system_restart();						// SDK function
+	// ESP.reset();				
+	abort ();									// Within a second
+}
+
+// ----------------------------------------------------------------------------
+// gway_failed is a function called by ASSERT in ESP-sc-gway.h
+//
+// ----------------------------------------------------------------------------
+void gway_failed (const char *file, uint16_t line) {
+	Serial.print (F ("Program failed in file: "));
+	Serial.print (file);
+	Serial.print (F (", line: "));
+	Serial.println (line);
+	if (debug >= 2) Serial.flush ();
+}
+
+// ----------------------------------------------------------------------------
+// Print leading '0' digits for hours(0) and second(0) when
+// printing values less than 10
+// ----------------------------------------------------------------------------
+void printDigits (unsigned long digits) {
+	// utility function for digital clock display: prints leading 0
+	if (digits < 10)
+		Serial.print (F ("0"));
+	Serial.print (digits);
+}
+
+// ----------------------------------------------------------------------------
+// Print utin8_t values in HEX with leading 0 when necessary
+// ----------------------------------------------------------------------------
+void printHexDigit (uint8_t digit) {
+	// utility function for printing Hex Values with leading 0
+	if (digit < 0x10)
+		Serial.print ('0');
+	Serial.print (digit, HEX);
+}
+
+
+// ----------------------------------------------------------------------------
+// Print the current time
+// ----------------------------------------------------------------------------
+static void printTime () {
+	switch (weekday ()) {
+		case 1: Serial.print (F ("Sunday")); break;
+		case 2: Serial.print (F ("Monday")); break;
+		case 3: Serial.print (F ("Tuesday")); break;
+		case 4: Serial.print (F ("Wednesday")); break;
+		case 5: Serial.print (F ("Thursday")); break;
+		case 6: Serial.print (F ("Friday")); break;
+		case 7: Serial.print (F ("Saturday")); break;
+		default: Serial.print (F ("ERROR")); break;
+	}
+	Serial.print (F (" "));
+	printDigits (hour ());
+	Serial.print (F (":"));
+	printDigits (minute ());
+	Serial.print (F (":"));
+	printDigits (second ());
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+// Convert a float to string for printing
+// Parameters:
+//	f is float value to convert
+//	p is precision in decimal digits
+//	val is character array for results
+// ----------------------------------------------------------------------------
+void ftoa (float f, char *val, int p) {
+	int j = 1;
+	int ival, fval;
+	char b[7] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+	for (int i = 0; i < p; i++) { j = j * 10; }
+
+	ival = (int)f;								// Make integer part
+	fval = (int)((f - ival)*j);					// Make fraction. Has same sign as integer part
+	if (fval < 0) fval = -fval;					// So if it is negative make fraction positive again.
+												// sprintf does NOT fit in memory
+	strcat (val, itoa (ival, b, 10));				// Copy integer part first, base 10, null terminated
+	strcat (val, ".");							// Copy decimal point
+
+	itoa (fval, b, 10);							// Copy fraction part base 10
+	for (int i = 0; i < (p - strlen (b)); i++) {
+		strcat (val, "0"); 						// first number of 0 of faction?
+	}
+
+	// Fraction can be anything from 0 to 10^p , so can have less digits
+	strcat (val, b);
+}
+
+// ============================================================================
+// NTP TIME functions
+
+
+
+// ----------------------------------------------------------------------------
+// Send the request packet to the NTP server.
+//
+// ----------------------------------------------------------------------------
+int sendNtpRequest (IPAddress timeServerIP) {
+	const int NTP_PACKET_SIZE = 48;				// Fixed size of NTP record
+	byte packetBuffer[NTP_PACKET_SIZE];
+
+	memset (packetBuffer, 0, NTP_PACKET_SIZE);	// Zeroise the buffer.
+
+	packetBuffer[0] = 0b11100011;   			// LI, Version, Mode
+	packetBuffer[1] = 0;						// Stratum, or type of clock
+	packetBuffer[2] = 6;						// Polling Interval
+	packetBuffer[3] = 0xEC;					// Peer Clock Precision
+	// 8 bytes of zero for Root Delay & Root Dispersion
+	packetBuffer[12] = 49;
+	packetBuffer[13] = 0x4E;
+	packetBuffer[14] = 49;
+	packetBuffer[15] = 52;
+
+
+	if (!sendUdp ((IPAddress)timeServerIP, (int)123, packetBuffer, NTP_PACKET_SIZE)) {
+		gwayConfig.ntpErr++;
+		gwayConfig.ntpErrTime = millis ();
+		return(0);
+	}
+	return(1);
+}
+
+
+// ----------------------------------------------------------------------------
+// Get the NTP time from one of the time servers
+// Note: As this function is called from SyncINterval in the background
+//	make sure we have no blocking calls in this function
+// ----------------------------------------------------------------------------
+time_t getNtpTime () {
+	gwayConfig.ntps++;
+
+	if (!sendNtpRequest (ntpServer))					// Send the request for new time
+	{
+		if (debug > 0) Serial.println (F ("sendNtpRequest failed"));
+		return(0);
+	}
+
+	const int NTP_PACKET_SIZE = 48;					// Fixed size of NTP record
+	byte packetBuffer[NTP_PACKET_SIZE];
+	memset (packetBuffer, 0, NTP_PACKET_SIZE);		// Set buffer cntents to zero
+
+	uint32_t beginWait = millis ();
+	delay (10);
+	while (millis () - beginWait < 1500) {
+		int size = Udp.parsePacket ();
+		if (size >= NTP_PACKET_SIZE) {
+
+			if (Udp.read (packetBuffer, NTP_PACKET_SIZE) < NTP_PACKET_SIZE) {
+				break;
+			} else {
+				// Extract seconds portion.
+				unsigned long secs;
+				secs = packetBuffer[40] << 24;
+				secs |= packetBuffer[41] << 16;
+				secs |= packetBuffer[42] << 8;
+				secs |= packetBuffer[43]; \
+					// UTC is 1 TimeZone correction when no daylight saving time
+					return(secs - 2208988800UL + NTP_TIMEZONES * SECS_PER_HOUR);
+			}
+			Udp.flush ();
+		}
+		delay (100);									// Wait 100 millisecs, allow kernel to act when necessary
+	}
+
+	Udp.flush ();
+
+	// If we are here, we could not read the time from internet
+	// So increase the counter
+	gwayConfig.ntpErr++;
+	gwayConfig.ntpErrTime = millis ();
+	if (debug > 0) Serial.println (F ("getNtpTime:: read failed"));
+	return(0); 										// return 0 if unable to get the time
+}
+
+// ----------------------------------------------------------------------------
+// Set up regular synchronization of NTP server and the local time.
+// ----------------------------------------------------------------------------
+#if NTP_INTR==1
+void setupTime () {
+	setSyncProvider (getNtpTime);
+	setSyncInterval (_NTP_INTERVAL);
+}
+#endif
+
+
+// ============================================================================
+// UDP AND WLAN FUNCTIONS
+
+
+// ----------------------------------------------------------------------------
+// config.txt is a text file that contains lines(!) with WPA configuration items
+// Each line contains an KEY vaue pair describing the gateway configuration
+//
+// ----------------------------------------------------------------------------
+int WlanReadWpa () {
+	int error = -1;
+	error = readConfig (CONFIGFILE, &gwayConfig);
+
+	if (gwayConfig.sf != (uint8_t)0) sf = (sf_t)gwayConfig.sf;
+	ifreq = gwayConfig.ch;
+	debug = gwayConfig.debug;
+	_cad = gwayConfig.cad;
+	_hop = gwayConfig.hop;
+	gwayConfig.boots++;							// Every boot of the system we increase the reset
+
+#if GATEWAYNODE==1
+	if (gwayConfig.fcnt != (uint8_t)0) frameCount = gwayConfig.fcnt + 10;
+#endif
+
+#if WIFIMANAGER > 0
+	String ssid = gwayConfig.ssid;
+	String pass = gwayConfig.pass;
+
+	char ssidBuf[ssid.length () + 1];
+	ssid.toCharArray (ssidBuf, ssid.length () + 1);
+	char passBuf[pass.length () + 1];
+	pass.toCharArray (passBuf, pass.length () + 1);
+	Serial.print (F ("WlanReadWpa: ")); Serial.print (ssidBuf); Serial.print (F (", ")); Serial.println (passBuf);
+
+	strcpy (wpa[0].login, ssidBuf);				// XXX changed from wpa[0][0] = ssidBuf
+	strcpy (wpa[0].passw, passBuf);
+
+	Serial.print (F ("WlanReadWpa: <"));
+	Serial.print (wpa[0].login); 				// XXX
+	Serial.print (F (">, <"));
+	Serial.print (wpa[0].passw);
+	Serial.println (F (">"));
+#endif
+	return error;
+}
+
+// ----------------------------------------------------------------------------
+// Print the WPA data of last WiFiManager to file
+// ----------------------------------------------------------------------------
+#if WIFIMANAGER==1
+int WlanWriteWpa (char* ssid, char *pass) {
+
+	Serial.print (F ("WlanWriteWpa:: ssid="));
+	Serial.print (ssid);
+	Serial.print (F (", pass="));
+	Serial.print (pass);
+	Serial.println ();
+
+	// Version 3.3 use of config file
+	String s ((char *)ssid);
+	gwayConfig.ssid = s;
+
+	String p ((char *)pass);
+	gwayConfig.pass = p;
+
+#if GATEWAYNODE==1	
+	gwayConfig.fcnt = frameCount;
+#endif
+	gwayConfig.ch = ifreq;
+	gwayConfig.sf = sf;
+	gwayConfig.cad = _cad;
+	gwayConfig.hop = _hop;
+
+	writeConfig (CONFIGFILE, &gwayConfig);
+	return 1;
+}
+#endif
+
+// ----------------------------------------------------------------------------
+// Function to join the Wifi Network
+//	It is a matter of returning to the main loop() asap and make sure in next loop
+//	the reconnect is done first thing.
+// Parameters:
+//		int maxTtry: Number of reties we do:
+//		0: Try forever. Which is normally what we want except for Setup maybe
+//		1: Try once and if unsuccessful return(0);
+//		x: Try x times
+//
+//  Returns:
+//		On failure: Return -1
+//		int number of retries necessary
+// ----------------------------------------------------------------------------
+int WlanConnect (int maxTry) {
+
+#if WIFIMANAGER==1
+	WiFiManager wifiManager;
+#endif
+
+	unsigned char agains = 0;
+	unsigned char wpa_index = (WIFIMANAGER > 0 ? 0 : 1);		// Skip over first record for WiFiManager
+
+	// So try to connect to WLAN as long as we are not connected.
+	// The try parameters tells us how many times we try before giving up
+	int i = 0;
+
+	// We try 5 times before giving up on connect
+	while ((WiFi.status () != WL_CONNECTED) && (i < maxTry)) {
+
+		// We try every SSID in wap array until success
+		for (int j = wpa_index; j < (sizeof (wpa) / sizeof (wpa[0])); j++) {
+
+			// Start with well-known access points in the list
+			char *ssid = wpa[j].login;
+			char *password = wpa[j].passw;
+
+			Serial.print (i);
+			Serial.print (':');
+			Serial.print (j);
+			Serial.print (F (". WiFi connect to: "));
+			Serial.println (ssid);
+
+			// Count the number of times we call WiFi.begin
+			gwayConfig.wifis++;
+			writeGwayCfg (CONFIGFILE);
+
+			WiFi.begin (ssid, password);
+
+			// We increase the time for connect but try the same SSID
+			// We try for 9 times
+			agains = 0;
+			while ((WiFi.status () != WL_CONNECTED) && (agains < 9)) {
+				delay (agains * 400);
+				agains++;
+				if (debug >= 2) Serial.print (".");
+			}
+			if (WiFi.status () == WL_CONNECTED)
+				break;
+			else
+				WiFi.disconnect ();
+		} //for
+		i++;													// Number of times we try to connect
+	}
+
+#if DUSB>=1
+	if (i > 0) {
+		Serial.print (F ("WLAN reconnected"));
+		Serial.println ();
+	}
+#endif
+
+	// Still not connected?
+	if (WiFi.status () != WL_CONNECTED) {
+#if WIFIMANAGER==1
+		Serial.println (F ("Starting Access Point Mode"));
+		Serial.print (F ("Connect Wifi to accesspoint: "));
+		Serial.print (AP_NAME);
+		Serial.print (F (" and connect to IP: 192.168.4.1"));
+		Serial.println ();
+		wifiManager.autoConnect (AP_NAME, AP_PASSWD);
+		//wifiManager.startConfigPortal(AP_NAME, AP_PASSWD );
+		// At this point, there IS a Wifi Access Point found and connected
+		// We must connect to the local SPIFFS storage to store the access point
+		//String s = WiFi.SSID();
+		//char ssidBuf[s.length()+1];
+		//s.toCharArray(ssidBuf,s.length()+1);
+		// Now look for the password
+		struct station_config sta_conf;
+		wifi_station_get_config (&sta_conf);
+
+		//WlanWriteWpa(ssidBuf, (char *)sta_conf.password);
+		WlanWriteWpa ((char *)sta_conf.ssid, (char *)sta_conf.password);
+#else
+		return(-1);
+#endif
+	}
+
+	yield ();
+
+	return(1);
+}
+
+
+// ----------------------------------------------------------------------------
+// Read DOWN a package from UDP socket, can come from any server
+// Messages are received when server responds to gateway requests from LoRa nodes 
+// (e.g. JOIN requests etc.) or when server has downstream data.
+// We repond only to the server that sent us a message!
+// Note: So normally we can forget here about codes that do upstream
+// Parameters:
+//	Packetsize: size of the buffer to read, as read by loop() calling function
+//
+// Returns:
+//	-1 or false if not read
+//	Or number of characters read is success
+//
+// ----------------------------------------------------------------------------
+int readUdp (int packetSize) {
+	uint8_t protocol;
+	uint16_t token;
+	uint8_t ident;
+	uint8_t buff[32]; 						// General buffer to use for UDP, set to 64
+	uint8_t buff_down[RX_BUFF_SIZE];		// Buffer for downstream
+
+	if (WlanConnect (10) < 0) {
+#if DUSB>=1
+		Serial.print (F ("readdUdp: ERROR connecting to WLAN"));
+		if (debug >= 2) Serial.flush ();
+#endif
+		Udp.flush ();
+		yield ();
+		return(-1);
+	}
+
+	yield ();
+
+	if (packetSize > RX_BUFF_SIZE) {
+#if DUSB>=1
+		Serial.print (F ("readUDP:: ERROR package of size: "));
+		Serial.println (packetSize);
+#endif
+		Udp.flush ();
+		return(-1);
+	}
+
+	// We assume here that we know the originator of the message
+	// In practice however this can be any sender!
+	if (Udp.read (buff_down, packetSize) < packetSize) {
+#if DUSB>=1
+		Serial.println (F ("readUsb:: Reading less chars"));
+		return(-1);
+#endif
+	}
+
+	// Remote Address should be known
+	IPAddress remoteIpNo = Udp.remoteIP ();
+
+	// Remote port is either of the remote TTN server or from NTP server (=123)
+	unsigned int remotePortNo = Udp.remotePort ();
+
+	if (remotePortNo == 123) {
+		// This is an NTP message arriving
+#if DUSB>=1
+		if (debug > 0) {
+			Serial.println (F ("readUdp:: NTP msg rcvd"));
+		}
+#endif
+		gwayConfig.ntpErr++;
+		gwayConfig.ntpErrTime = millis ();
+		return(0);
+	}
+
+	// If it is not NTP it must be a LoRa message for gateway or node
+	else {
+		uint8_t *data = (uint8_t *)((uint8_t *)buff_down + 4);
+		protocol = buff_down[0];
+		token = buff_down[2] * 256 + buff_down[1];
+		ident = buff_down[3];
+
+		// now parse the message type from the server (if any)
+		switch (ident) {
+
+			// This message is used by the gateway to send sensor data to the
+			// server. As this function is used for downstream only, this option
+			// will never be selected but is included as a reference only
+			case PKT_PUSH_DATA: // 0x00 UP
+#if DUSB>=1
+				if (debug >= 1) {
+					Serial.print (F ("PKT_PUSH_DATA:: size ")); Serial.print (packetSize);
+					Serial.print (F (" From ")); Serial.print (remoteIpNo);
+					Serial.print (F (", port ")); Serial.print (remotePortNo);
+					Serial.print (F (", data: "));
+					for (int i = 0; i < packetSize; i++) {
+						Serial.print (buff_down[i], HEX);
+						Serial.print (':');
+					}
+					Serial.println ();
+					if (debug >= 2) Serial.flush ();
+				}
+#endif
+				break;
+
+				// This message is sent by the server to acknoledge receipt of a
+				// (sensor) message sent with the code above.
+			case PKT_PUSH_ACK:	// 0x01 DOWN
+#if DUSB>=1
+				if (debug >= 2) {
+					Serial.print (F ("PKT_PUSH_ACK:: size "));
+					Serial.print (packetSize);
+					Serial.print (F (" From "));
+					Serial.print (remoteIpNo);
+					Serial.print (F (", port "));
+					Serial.print (remotePortNo);
+					Serial.print (F (", token: "));
+					Serial.println (token, HEX);
+					Serial.println ();
+				}
+#endif
+				break;
+
+			case PKT_PULL_DATA:	// 0x02 UP
+#if DUSB>=1
+				Serial.print (F (" Pull Data"));
+				Serial.println ();
+#endif
+				break;
+
+				// This message type is used to confirm OTAA message to the node
+				// XXX This message format may also be used for other downstream communucation
+			case PKT_PULL_RESP:	// 0x03 DOWN
+#if DUSB>=1
+				if (debug >= 0) {
+					Serial.println (F ("PKT_PULL_RESP:: received"));
+				}
+#endif
+				lastTmst = micros ();					// Store the tmst this package was received
+
+				// Send to the LoRa Node first (timing) and then do messaging
+				_state = S_TX;
+				if (sendPacket (data, packetSize - 4) < 0) {
+					return(-1);
+				}
+
+				// Now respond with an PKT_TX_ACK; 0x04 UP
+				buff[0] = buff_down[0];
+				buff[1] = buff_down[1];
+				buff[2] = buff_down[2];
+				//buff[3]=PKT_PULL_ACK;				// Pull request/Change of Mogyi
+				buff[3] = PKT_TX_ACK;
+				buff[4] = MAC_array[0];
+				buff[5] = MAC_array[1];
+				buff[6] = MAC_array[2];
+				buff[7] = 0xFF;
+				buff[8] = 0xFF;
+				buff[9] = MAC_array[3];
+				buff[10] = MAC_array[4];
+				buff[11] = MAC_array[5];
+				buff[12] = 0;
+#if DUSB>=1
+				Serial.println (F ("readUdp:: TX buff filled"));
+#endif
+				// Only send the PKT_PULL_ACK to the UDP socket that just sent the data!!!
+				Udp.beginPacket (remoteIpNo, remotePortNo);
+#ifdef ESP32BUILD
+				if (Udp.write (buff, 12) != 12) {
+#else
+				if (Udp.write ((char *)buff, 12) != 12) {
+#endif
+#if DUSB>=1
+					if (debug >= 0)
+						Serial.println ("PKT_PULL_ACK:: Error UDP write");
+#endif
+				} else {
+#if DUSB>=1
+					if (debug >= 0) {
+						Serial.print (F ("PKT_TX_ACK:: tmst="));
+						Serial.println (micros ());
+					}
+#endif
+				}
+
+				if (!Udp.endPacket ()) {
+#if DUSB>=1
+					if (debug >= 0)
+						Serial.println (F ("PKT_PULL_DATALL Error Udp.endpaket"));
+#endif
+				}
+
+				yield ();
+#if DUSB>=1
+				if (debug >= 1) {
+					Serial.print (F ("PKT_PULL_RESP:: size "));
+					Serial.print (packetSize);
+					Serial.print (F (" From "));
+					Serial.print (remoteIpNo);
+					Serial.print (F (", port "));
+					Serial.print (remotePortNo);
+					Serial.print (F (", data: "));
+					data = buff_down + 4;
+					data[packetSize] = 0;
+					Serial.print ((char *)data);
+					Serial.println (F ("..."));
+				}
+#endif		
+				break;
+
+			case PKT_PULL_ACK:	// 0x04 DOWN; the server sends a PULL_ACK to confirm PULL_DATA receipt
+#if DUSB>=1
+				if (debug >= 2) {
+					Serial.print (F ("PKT_PULL_ACK:: size ")); Serial.print (packetSize);
+					Serial.print (F (" From ")); Serial.print (remoteIpNo);
+					Serial.print (F (", port ")); Serial.print (remotePortNo);
+					Serial.print (F (", data: "));
+					for (int i = 0; i < packetSize; i++) {
+						Serial.print (buff_down[i], HEX);
+						Serial.print (':');
+					}
+					Serial.println ();
+				}
+#endif
+				break;
+
+			default:
+#if GATEWAYMGT==1
+				// For simplicity, we send the first 4 bytes too
+				gateway_mgt (packetSize, buff_down);
+#else
+
+#endif
+#if DUSB>=1
+				Serial.print (F (", ERROR ident not recognized="));
+				Serial.println (ident);
+#endif
+				break;
+		}
+#if DUSB>=2
+		if (debug >= 1) {
+			Serial.print (F ("readUdp:: returning="));
+			Serial.println (packetSize);
+		}
+#endif
+		// For downstream messages
+		return packetSize;
+	}
+}//readUdp
+
+
+// ----------------------------------------------------------------------------
+// Send UP an UDP/DGRAM message to the MQTT server
+// If we send to more than one host (not sure why) then we need to set sockaddr 
+// before sending.
+// Parameters:
+//	IPAddress
+//	port
+//	msg *
+//	length (of msg)
+// return values:
+//	0: Error
+//	1: Success
+// ----------------------------------------------------------------------------
+int sendUdp (IPAddress server, int port, uint8_t *msg, int length) {
+
+	// Check whether we are conected to Wifi and the internet
+	if (WlanConnect (3) < 0) {
+#if DUSB>=1
+		Serial.print (F ("sendUdp: ERROR connecting to WiFi"));
+		Serial.flush ();
+#endif
+		Udp.flush ();
+		yield ();
+		return(0);
+	}
+
+	yield ();
+
+	//send the update
+#if DUSB>=1
+	if (debug >= 2) Serial.println (F ("WiFi connected"));
+#endif	
+	if (!Udp.beginPacket (server, (int)port)) {
+#if DUSB>=1
+		if (debug >= 1) Serial.println (F ("sendUdp:: Error Udp.beginPacket"));
+#endif
+		return(0);
+	}
+
+	yield ();
+
+#ifdef ESP32BUILD
+	if (Udp.write (msg, length) != length) {
+#else
+	if (Udp.write ((char *)msg, length) != length) {
+#endif
+#if DUSB>=1
+		Serial.println (F ("sendUdp:: Error write"));
+#endif
+		Udp.endPacket ();						// Close UDP
+		return(0);								// Return error
+	}
+
+	yield ();
+
+	if (!Udp.endPacket ()) {
+#if DUSB>=1
+		if (debug >= 1) {
+			Serial.println (F ("sendUdp:: Error Udp.endPacket"));
+			Serial.flush ();
+		}
+#endif
+		return(0);
+	}
+	return(1);
+}//sendUDP
+
+// ----------------------------------------------------------------------------
+// UDPconnect(): connect to UDP (which is a local thing, after all UDP 
+// connections do not exist.
+// Parameters:
+//	<None>
+// Returns
+//	Boollean indicating success or not
+// ----------------------------------------------------------------------------
+bool UDPconnect () {
+
+	bool ret = false;
+	unsigned int localPort = _LOCUDPPORT;			// To listen to return messages from WiFi
+#if DUSB>=1
+	if (debug >= 1) {
+		Serial.print (F ("Local UDP port="));
+		Serial.println (localPort);
+	}
+#endif	
+	if (Udp.begin (localPort) == 1) {
+#if DUSB>=1
+		if (debug >= 1) Serial.println (F ("Connection successful"));
+#endif
+		ret = true;
+	} else {
+#if DUSB>=1
+		if (debug >= 1) Serial.println ("Connection failed");
+#endif
+	}
+	return(ret);
+}//udpConnect
+
+
+// ----------------------------------------------------------------------------
+// Send UP periodic Pull_DATA message to server to keepalive the connection
+// and to invite the server to send downstream messages when these are available
+// *2, par. 5.2
+//	- Protocol Version (1 byte)
+//	- Random Token (2 bytes)
+//	- PULL_DATA identifier (1 byte) = 0x02
+//	- Gateway unique identifier (8 bytes) = MAC address
+// ----------------------------------------------------------------------------
+void pullData () {
+
+	uint8_t pullDataReq[12]; 								// status report as a JSON object
+	int pullIndex = 0;
+	int i;
+
+	uint8_t token_h = (uint8_t)rand (); 						// random token
+	uint8_t token_l = (uint8_t)rand ();						// random token
+
+	// pre-fill the data buffer with fixed fields
+	pullDataReq[0] = PROTOCOL_VERSION;						// 0x01
+	pullDataReq[1] = token_h;
+	pullDataReq[2] = token_l;
+	pullDataReq[3] = PKT_PULL_DATA;						// 0x02
+	// READ MAC ADDRESS OF ESP8266, and return unique Gateway ID consisting of MAC address and 2bytes 0xFF
+	pullDataReq[4] = MAC_array[0];
+	pullDataReq[5] = MAC_array[1];
+	pullDataReq[6] = MAC_array[2];
+	pullDataReq[7] = 0xFF;
+	pullDataReq[8] = 0xFF;
+	pullDataReq[9] = MAC_array[3];
+	pullDataReq[10] = MAC_array[4];
+	pullDataReq[11] = MAC_array[5];
+	//pullDataReq[12] = 0/00; 								// add string terminator, for safety
+
+	pullIndex = 12;											// 12-byte header
+
+	//send the update
+
+	uint8_t *pullPtr;
+	pullPtr = pullDataReq,
+#ifdef _TTNSERVER
+		sendUdp (ttnServer, _TTNPORT, pullDataReq, pullIndex);
+	yield ();
+#endif
+
+#if DUSB>=1
+	if (pullPtr != pullDataReq) {
+		Serial.println (F ("pullPtr != pullDatReq"));
+		Serial.flush ();
+	}
+
+#endif
+#ifdef _THINGSERVER
+	sendUdp (thingServer, _THINGPORT, pullDataReq, pullIndex);
+#endif
+
+#if DUSB>=1
+	if (debug >= 2) {
+		yield ();
+		Serial.print (F ("PKT_PULL_DATA request, len=<"));
+		Serial.print (pullIndex);
+		Serial.print (F ("> "));
+		for (i = 0; i < pullIndex; i++) {
+			Serial.print (pullDataReq[i], HEX);				// DEBUG: display JSON stat
+			Serial.print (':');
+		}
+		Serial.println ();
+		if (debug >= 2) Serial.flush ();
+	}
+#endif
+	return;
+}//pullData
+
+
+// ----------------------------------------------------------------------------
+// Send UP periodic status message to server even when we do not receive any
+// data. 
+// Parameters:
+//	- <none>
+// ----------------------------------------------------------------------------
+void sendstat () {
+
+	uint8_t status_report[STATUS_SIZE]; 					// status report as a JSON object
+	char stat_timestamp[32];								// XXX was 24
+	time_t t;
+	char clat[10] = {0};
+	char clon[10] = {0};
+
+	int stat_index = 0;
+	uint8_t token_h = (uint8_t)rand (); 					// random token
+	uint8_t token_l = (uint8_t)rand ();					// random token
+
+	// pre-fill the data buffer with fixed fields
+	status_report[0] = PROTOCOL_VERSION;					// 0x01
+	status_report[1] = token_h;
+	status_report[2] = token_l;
+	status_report[3] = PKT_PUSH_DATA;						// 0x00
+
+	// READ MAC ADDRESS OF ESP8266, and return unique Gateway ID consisting of MAC address and 2bytes 0xFF
+	status_report[4] = MAC_array[0];
+	status_report[5] = MAC_array[1];
+	status_report[6] = MAC_array[2];
+	status_report[7] = 0xFF;
+	status_report[8] = 0xFF;
+	status_report[9] = MAC_array[3];
+	status_report[10] = MAC_array[4];
+	status_report[11] = MAC_array[5];
+
+	stat_index = 12;										// 12-byte header
+
+	t = now ();												// get timestamp for statistics
+
+	// XXX Using CET as the current timezone. Change to your timezone	
+	sprintf (stat_timestamp, "%04d-%02d-%02d %02d:%02d:%02d CET", year (), month (), day (), hour (), minute (), second ());
+	yield ();
+
+	ftoa (lat, clat, 5);										// Convert lat to char array with 5 decimals
+	ftoa (lon, clon, 5);										// As IDE CANNOT prints floats
+
+	// Build the Status message in JSON format, XXX Split this one up...
+	delay (1);
+
+	int j = snprintf ((char *)(status_report + stat_index), STATUS_SIZE - stat_index,
+		"{\"stat\":{\"time\":\"%s\",\"lati\":%s,\"long\":%s,\"alti\":%i,\"rxnb\":%u,\"rxok\":%u,\"rxfw\":%u,\"ackr\":%u.0,\"dwnb\":%u,\"txnb\":%u,\"pfrm\":\"%s\",\"mail\":\"%s\",\"desc\":\"%s\"}}",
+		stat_timestamp, clat, clon, (int)alt, cp_nb_rx_rcv, cp_nb_rx_ok, cp_up_pkt_fwd, 0, 0, 0, platform, email, description);
+
+	yield ();												// Give way to the internal housekeeping of the ESP8266
+
+	stat_index += j;
+	status_report[stat_index] = 0; 							// add string terminator, for safety
+
+	if (debug >= 2) {
+		Serial.print (F ("stat update: <"));
+		Serial.print (stat_index);
+		Serial.print (F ("> "));
+		Serial.println ((char *)(status_report + 12));			// DEBUG: display JSON stat
+	}
+
+	if (stat_index > STATUS_SIZE) {
+		Serial.println (F ("sendstat:: ERROR buffer too big"));
+		return;
+	}
+
+	//send the update
+#ifdef _TTNSERVER
+	sendUdp (ttnServer, _TTNPORT, status_report, stat_index);
+	yield ();
+#endif
+
+#ifdef _THINGSERVER
+	sendUdp (thingServer, _THINGPORT, status_report, stat_index);
+#endif
+	return;
+}//sendstat
+
+
+
+// ============================================================================
+// MAIN PROGRAM CODE (SETUP AND LOOP)
+
+
+// ----------------------------------------------------------------------------
+// Setup code (one time)
+// _state is S_INIT
+// ----------------------------------------------------------------------------
+void setup () {
+
+	char MAC_char[19];								// XXX Unbelievable
+	MAC_char[18] = 0;
+
+
+
+	Serial.begin (_BAUDRATE);						// As fast as possible for bus
+	delay (100);
+	Serial.flush ();
+	delay (500);
+#if MUTEX_SPI==1
+	CreateMutux (&inSPI);
+#endif
+#if MUTEX_SPO==1
+	CreateMutux (&inSPO);
+#endif
+#if MUTEX_INT==1
+	CreateMutux (&inIntr);
+#endif
+	if (SPIFFS.begin ()) Serial.println (F ("SPIFFS loaded success"));
+
+	Serial.print (F ("Assert="));
+#if defined CFG_noassert
+	Serial.println (F ("No Asserts"));
+#else
+	Serial.println (F ("Do Asserts"));
+#endif
+
+#if OLED==1
+	// Initialising the UI will init the display too.
+#ifdef ESP32BUILD
+	pinMode (16, OUTPUT);
+	digitalWrite (16, LOW);    // set GPIO16 low to reset OLED
+	delay (50);
+	digitalWrite (16, HIGH); // while OLED is running, must set GPIO16 in high、
+#endif
+	display.init ();
+	display.flipScreenVertically ();
+	display.setFont (ArialMT_Plain_24);
+	display.setTextAlignment (TEXT_ALIGN_LEFT);
+	display.drawString (0, 24, "STARTING");
+	display.display ();
+#endif
+
+	delay (500);
+	yield ();
+#if DUSB>=1	
+	if (debug >= 1) {
+		Serial.print (F ("debug="));
+		Serial.println (debug);
+		yield ();
+	}
+#endif
+	WiFi.mode (WIFI_STA);
+	WlanReadWpa ();								// Read the last Wifi settings from SPIFFS into memory
+
+	WiFi.macAddress (MAC_array);
+
+	sprintf (MAC_char, "%02x:%02x:%02x:%02x:%02x:%02x",
+		MAC_char[0], MAC_array[1], MAC_char[2], MAC_array[3], MAC_char[4], MAC_array[5]);
+	Serial.print ("MAC: ");
+	Serial.print (MAC_char);
+	Serial.print (F (", len="));
+	Serial.println (strlen (MAC_char));
+
+	// We start by connecting to a WiFi network, set hostname
+	char hostname[12];
+#ifdef ESP32BUILD
+	sprintf (hostname, "%s%02x%02x%02x", "esp32-", MAC_array[3], MAC_array[4], MAC_array[5]);
+#else
+	sprintf (hostname, "%s%02x%02x%02x", "esp8266-", MAC_array[3], MAC_array[4], MAC_array[5]);
+#endif
+
+#ifdef ESP32BUILD
+	WiFi.setHostname (hostname);
+#else
+	wifi_station_set_hostname (hostname);
+#endif
+
+	// Setup WiFi UDP connection. Give it some time and retry 50 times..
+	while (WlanConnect (50) < 0) {
+		Serial.print (F ("Error Wifi network connect "));
+		Serial.println ();
+		yield ();
+	}
+
+	Serial.print (F ("Host "));
+#ifdef ESP32BUILD
+	Serial.print (WiFi.getHostname ());
+#else
+	Serial.print (wifi_station_get_hostname ());
+#endif
+	Serial.print (F (" WiFi Connected to "));
+	Serial.print (WiFi.SSID ());
+	Serial.println ();
+	delay (200);
+
+	// If we are here we are connected to WLAN
+	// So now test the UDP function
+	if (!UDPconnect ()) {
+		Serial.println (F ("Error UDPconnect"));
+	}
+	delay (200);
+
+	// Pins are defined and set in loraModem.h
+	pinMode (pins.ss, OUTPUT);
+	pinMode (pins.rst, OUTPUT);
+	pinMode (pins.dio0, INPUT);								// This pin is interrupt
+	pinMode (pins.dio1, INPUT);								// This pin is interrupt
+	//pinMode(pins.dio2, INPUT);
+
+	// Init the SPI pins
+#ifdef ESP32BUILD
+	SPI.begin (SCK, MISO, MOSI, SS);
+#else
+	SPI.begin ();
+#endif
+
+	delay (500);
+
+	// We choose the Gateway ID to be the Ethernet Address of our Gateway card
+	// display results of getting hardware address
+	// 
+	Serial.print ("Gateway ID: ");
+	printHexDigit (MAC_array[0]);
+	printHexDigit (MAC_array[1]);
+	printHexDigit (MAC_array[2]);
+	printHexDigit (0xFF);
+	printHexDigit (0xFF);
+	printHexDigit (MAC_array[3]);
+	printHexDigit (MAC_array[4]);
+	printHexDigit (MAC_array[5]);
+
+	Serial.print (", Listening at SF");
+	Serial.print (sf);
+	Serial.print (" on ");
+	Serial.print ((double)freq / 1000000);
+	Serial.println (" Mhz.");
+
+	if (!WiFi.hostByName (NTP_TIMESERVER, ntpServer))		// Get IP address of Timeserver
+	{
+		die ("Setup:: ERROR hostByName NTP");
+	};
+	delay (100);
+#ifdef _TTNSERVER
+	if (!WiFi.hostByName (_TTNSERVER, ttnServer))			// Use DNS to get server IP once
+	{
+		die ("Setup:: ERROR hostByName TTN");
+	};
+	delay (100);
+#endif
+#ifdef _THINGSERVER
+	if (!WiFi.hostByName (_THINGSERVER, thingServer)) {
+		die ("Setup:: ERROR hostByName THING");
+	}
+	delay (100);
+#endif
+
+	// The Over the AIr updates are supported when we have a WiFi connection.
+	// The NTP time setting does not have to be precise for this function to work.
+#if A_OTA==1
+	setupOta (hostname);										// Uses wwwServer 
+#endif
+
+	// Set the NTP Time
+#if NTP_INTR==1
+	setupTime ();											// Set NTP time host and interval
+#else
+	//setTime((time_t)getNtpTime());
+	while (timeStatus () == timeNotSet) {
+		Serial.println (F ("setupTime:: Time not set (yet)"));
+		delay (500);
+		time_t newTime;
+		newTime = (time_t)getNtpTime ();
+		if (newTime != 0) setTime (newTime);
+	}
+	Serial.print ("Time: "); printTime ();
+	Serial.println ();
+
+	writeGwayCfg (CONFIGFILE);
+	Serial.println (F ("Gateway configuration saved"));
+#endif
+
+#if A_SERVER==1	
+	// Setup the webserver
+	setupWWW ();
+#endif
+
+	delay (100);												// Wait after setup
+
+	// Setup and initialise LoRa state machine of _loramModem.ino
+	_state = S_INIT;
+	initLoraModem ();
+
+	if (_cad) {
+		_state = S_SCAN;
+		cadScanner ();										// Always start at SF7
+	} else {
+		_state = S_RX;
+		rxLoraModem ();
+	}
+	LoraUp.payLength = 0;						// Init the length to 0
+
+	// init interrupt handlers, which are shared for GPIO15 / D8, 
+	// we switch on HIGH interrupts
+	if (pins.dio0 == pins.dio1) {
+		//SPI.usingInterrupt(digitalPinToInterrupt(pins.dio0));
+		attachInterrupt (pins.dio0, Interrupt_0, RISING);		// Share interrupts
+	}
+	// Or in the traditional Comresult case
+	else {
+		//SPI.usingInterrupt(digitalPinToInterrupt(pins.dio0));
+		//SPI.usingInterrupt(digitalPinToInterrupt(pins.dio1));
+		attachInterrupt (pins.dio0, Interrupt_0, RISING);	// Separate interrupts
+		attachInterrupt (pins.dio1, Interrupt_1, RISING);	// Separate interrupts		
+	}
+
+	writeConfig (CONFIGFILE, &gwayConfig);					// Write config
+
+	// activate OLED display
+#if OLED==1
+	// Initialising the UI will init the display too.
+	display.clear ();
+	display.setFont (ArialMT_Plain_24);
+	display.drawString (0, 24, "READY");
+	display.display ();
+#endif
+
+	Serial.println (F ("--------------------------------------"));
+}//setup
+
+
+
+// ----------------------------------------------------------------------------
+// LOOP
+// This is the main program that is executed time and time again.
+// We need to give way to the backend WiFi processing that 
+// takes place somewhere in the ESP8266 firmware and therefore
+// we include yield() statements at important points.
+//
+// Note: If we spend too much time in user processing functions
+//	and the backend system cannot do its housekeeping, the watchdog
+// function will be executed which means effectively that the 
+// program crashes.
+// We use yield() a lot to avoid ANY watch dog activity of the program.
+//
+// NOTE2: For ESP make sure not to do large array declarations in loop();
+// ----------------------------------------------------------------------------
+void loop () {
+	uint32_t nowSeconds;
+	int packetSize;
+
+	nowTime = micros ();
+	nowSeconds = (uint32_t)millis () / 1000;
+
+	// check for event value, which means that an interrupt has arrived.
+	// In this case we handle the interrupt ( e.g. message received)
+	// in userspace in loop().
+	//
+	if (_event != 0x00) {
+		stateMachine ();					// start the state machine
+		_event = 0;						// reset value
+		return;							// Restart loop
+	}
+
+	// After a quiet period, make sure we reinit the modem.
+	// XXX Still have to measure quiet period in stat[0];
+	// For the moment we use msgTime
+	if ((((nowTime - statr[0].tmst) / 1000000) > _MSG_INTERVAL) &&
+		(msgTime < statr[0].tmst)) {
+#if DUSB>=1
+		Serial.print ('r');
+#endif
+		initLoraModem ();
+		if (_cad) {
+			_state = S_SCAN;
+			cadScanner ();
+		} else {
+			_state = S_RX;
+			rxLoraModem ();
+		}
+		writeRegister (REG_IRQ_FLAGS_MASK, (uint8_t)0x00);
+		writeRegister (REG_IRQ_FLAGS, 0xFF);				// Reset all interrupt flags
+		msgTime = nowTime;
+	}
+
+#if A_OTA==1
+	// Perform Over the Air (OTA) update if enabled and requested by user.
+	// It is important to put this function at the start of loop() as it is
+	// not called frequently but it should always run when called.
+	//
+	yield ();
+	ArduinoOTA.handle ();
+#endif
+
+#if A_SERVER==1
+	// Handle the WiFi server part of this sketch. Mainly used for administration 
+	// and monitoring of the node. This function is important so it is called at the
+	// start of the loop() function
+	yield ();
+	server.handleClient ();
+#endif
+
+
+	// If we are not connected, try to connect.
+	// We will not read Udp in this loop cycle then
+	if (WlanConnect (1) < 0) {
+#if DUSB>=1
+		Serial.print (F ("loop: ERROR reconnect WLAN"));
+#endif
+		yield ();
+		return;										// Exit loop if no WLAN connected
+	}
+
+	// So if we are connected 
+	// Receive UDP PUSH_ACK messages from server. (*2, par. 3.3)
+	// This is important since the TTN broker will return confirmation
+	// messages on UDP for every message sent by the gateway. So we have to consume them..
+	// As we do not know when the server will respond, we test in every loop.
+	//
+	else {
+		while ((packetSize = Udp.parsePacket ()) > 0) {		// Length of UDP message waiting
+#if DUSB>=2
+			Serial.println (F ("loop:: readUdp calling"));
+#endif
+			// Packet may be PKT_PUSH_ACK (0x01), PKT_PULL_ACK (0x03) or PKT_PULL_RESP (0x04)
+			// This command is found in byte 4 (buffer[3])
+			if (readUdp (packetSize) <= 0) {
+#if DUSB>=1
+				if (debug > 0) Serial.println (F ("readUDP error"));
+#endif
+				break;
+			}
+			// Now we know we succesfull received message from host
+			else {
+				_event = 1;									// Could be done double if more messages received
+			}
+			//yield();
+		}
+	}
+
+	yield ();
+
+
+	// The next section is emergency only. If posible we hop() in the state machine.
+	// If hopping is enabled, and by lack of timer, we hop()
+	// XXX Experimental, 2.5 ms between hops max
+	//
+
+	if ((_hop) && (((long)(nowTime - hopTime)) > 7500)) {
+
+		if ((_state == S_SCAN) && (sf == SF12)) {
+#if DUSB>=1
+			if (debug >= 1) Serial.println (F ("loop:: hop"));
+#endif
+			hop ();
+		}
+
+		// XXX section below does not work without further work. It is the section with the MOST
+		// influence on the HOP mode of operation (which is somewhat unexpected)
+		// If we keep staying in another state, reset
+		else if (((long)(nowTime - hopTime)) > 100000) {
+
+			_state = S_RX;
+			rxLoraModem ();
+
+			hop ();
+
+			if (_cad) {
+				_state = S_SCAN;
+				cadScanner ();
+			}
+		} else if (debug >= 3) { Serial.print (F (" state=")); Serial.println (_state); }
+		inHop = false;									// Reset re-entrane protection of HOP
+		yield ();
+	}
+
+
+
+	// stat PUSH_DATA message (*2, par. 4)
+	//	
+
+	if ((nowSeconds - stattime) >= _STAT_INTERVAL) {	// Wake up every xx seconds
+#if DUSB>=1
+		if (debug >= 2) {
+			Serial.print (F ("STAT <"));
+			Serial.flush ();
+		}
+#endif
+		sendstat ();										// Show the status message and send to server
+#if DUSB>=1
+		if (debug >= 2) {
+			Serial.println (F (">"));
+			if (debug >= 2) Serial.flush ();
+		}
+#endif	
+
+		// If the gateway behaves like a node, we do from time to time
+		// send a node message to the backend server.
+		// The Gateway nod emessage has nothing to do with the STAT_INTERVAL
+		// message but we schedule it in the same frequency.
+		//
+#if GATEWAYNODE==1
+		if (gwayConfig.isNode) {
+			// Give way to internal Admin if necessary
+			yield ();
+
+			// If the 1ch gateway is a sensor itself, send the sensor values
+			// could be battery but also other status info or sensor info
+
+			if (sensorPacket () < 0) {
+				Serial.println (F ("sensorPacket: Error"));
+			}
+		}
+#endif
+		stattime = nowSeconds;
+	}
+
+	yield ();
+
+
+	// send PULL_DATA message (*2, par. 4)
+	//
+	nowSeconds = (uint32_t)millis () / 1000;
+	if ((nowSeconds - pulltime) >= _PULL_INTERVAL) {	// Wake up every xx seconds
+#if DUSB>=1
+		if (debug >= 1) {
+			Serial.print (F ("PULL <"));
+			if (debug >= 2) Serial.flush ();
+		}
+#endif
+		pullData ();										// Send PULL_DATA message to server
+		initLoraModem ();
+		if (_cad) {
+			_state = S_SCAN;
+			cadScanner ();
+		} else {
+			_state = S_RX;
+			rxLoraModem ();
+		}
+		writeRegister (REG_IRQ_FLAGS_MASK, (uint8_t)0x00);
+		writeRegister (REG_IRQ_FLAGS, 0xFF);				// Reset all interrupt flags
+#if DUSB>=1
+		if (debug >= 1) {
+			Serial.println (F (">"));
+			if (debug >= 2) Serial.flush ();
+		}
+#endif		
+		pulltime = nowSeconds;
+	}
+
+
+	// If we do our own NTP handling (advisable)
+	// We do not use the timer interrupt but use the timing
+	// of the loop() itself which is better for SPI
+#if NTP_INTR==0
+	// Set the time in a manual way. Do not use setSyncProvider
+	// as this function may collide with SPI and other interrupts
+	yield ();
+	nowSeconds = (uint32_t)millis () / 1000;
+	if (nowSeconds - ntptimer >= _NTP_INTERVAL) {
+		yield ();
+		time_t newTime;
+		newTime = (time_t)getNtpTime ();
+		if (newTime != 0) setTime (newTime);
+		ntptimer = nowSeconds;
+	}
+#endif
+}

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/LICENSE.md
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016,2017 Maarten Westenberg (mw12554@hotmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/LICENSE.txt
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Maarten Westenberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_gatewayMgt.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_gatewayMgt.ino
@@ -1,0 +1,82 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg 
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// Based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+// and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg
+//
+// This file contains the functions to do management over UDP
+// We could make use of the LoRa message function for the Gateway sensor
+// itself. However the functions defined in this file are not sensor
+// functions and activating them through the LoRa interface would add
+// no value and make the code more complex.
+//
+// So advantage: Simple, and does not mess with TTN setup.
+//
+// Disadvantage of course is that you need to setup you own small backend
+// function to exchange messages with the gateway, as TTN won't do this.
+//
+// XXX But, if necessary we can always add this later.
+
+#if GATEWAYMGT==1
+
+#if !defined _THINGPORT
+#error "The management functions needs _THINGPORT defined (and not over _TTNPORT)"
+#endif
+
+
+
+// ----------------------------------------------------------------------------
+// Ths function gateway_mgt is called in the UDP Receive function after
+// all well-known LoRa Gateway messages are scanned.
+//
+// As part of this function we will listen for another set of messages
+// that is defined in loraModem.h.
+// All opCodes start with 0x1y for at leaving opcodes 0x00 to 0x0F to the
+// pure Gateway protocol
+//
+// Incoming mesage format:
+//	buf[0]-buf[2], These are 0x00 or dont care
+//	buf[3], contains opcode
+//	buf[4]-buf[7], contains parameter max. 4 bytes.
+//
+// Upstream Message format:
+//
+// ----------------------------------------------------------------------------
+void gateway_mgt(uint8_t size, uint8_t *buff) {
+
+	uint8_t opcode = buff[3];
+	
+	switch (opcode) {
+		case MGT_RESET:
+			Serial.println(F("gateway_mgt:: RESET"));
+			// No further parameters, just reset the GWay
+			setup();								// Call the sketch setup function
+			// Send Ack to server
+			
+		break;
+		case MGT_SET_SF:
+			Serial.println(F("gateway_mgt:: SET SF"));
+			// byte [4] contains desired SF code (7 for SF7 and 12 for SF12)
+		break;
+		case MGT_SET_FREQ:
+			Serial.println(F("gateway_mgt:: SET FREQ"));
+			// Byte [4] contains index of Frequency
+		break;
+		default:
+			Serial.print(F("gateway_mgt:: Unknown UDP code=")); 
+			Serial.println(opcode);
+			return;
+		break;
+	}
+}
+
+#endif //GATEWAYMGT==1

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_loraFiles.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_loraFiles.ino
@@ -1,0 +1,195 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+//	and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains the LoRa filesystem specific code
+
+
+// ============================================================================
+// LORA SPIFFS FILESYSTEM FUNCTIONS
+//
+// The LoRa supporting functions are in the section below
+
+// ----------------------------------------------------------------------------
+// Directory listing. s is a string containing HTML/text code so far.
+// The resulting directory listing is appended to s and returned.
+// ----------------------------------------------------------------------------
+//String espDir(String s) {
+//
+//	return s;
+//}
+
+// ----------------------------------------------------------------------------
+// Read the gateway configuration file
+// ----------------------------------------------------------------------------
+int readConfig(const char *fn, struct espGwayConfig *c) {
+
+	Serial.println(F("readConfig:: Starting"));
+
+	if (!SPIFFS.exists(fn)) {
+		Serial.print(F("ERROR:: readConfig, file does not exist "));
+		Serial.println(fn);
+		return(-1);
+	}
+	File f = SPIFFS.open(fn, "r");
+	if (!f) {
+		Serial.println(F("ERROR:: SPIFFS open failed"));
+		return(-1);
+	}
+
+	while (f.available()) {
+		
+		String id =f.readStringUntil('=');
+		String val=f.readStringUntil('\n');
+		
+		if (id == "SSID") {									// WiFi SSID
+			Serial.print(F("SSID=")); Serial.println(val);
+			(*c).ssid = val;								// val contains ssid, we do NO check
+		}
+		//if (id == "PASS") { 								// WiFi Password
+		//	Serial.print(F("PASS=")); Serial.println(val); 
+		//	(*c).pass = val;
+		//}
+		if (id == "CH") { 									// Frequency Channel
+			Serial.print(F("CH=")); Serial.println(val); 
+			(*c).ch = (uint32_t) val.toInt();
+		}
+		if (id == "SF") { 									// Spreading Factor
+			Serial.print(F("SF  =")); Serial.println(val);
+			(*c).sf = (uint32_t) val.toInt();
+		}
+		if (id == "FCNT") {									// Frame Counter
+			Serial.print(F("FCNT=")); Serial.println(val);
+			(*c).fcnt = (uint32_t) val.toInt();
+		}
+		if (id == "DEBUG") {								// Frame Counter
+			Serial.print(F("DEBUG=")); Serial.println(val);
+			(*c).debug = (uint8_t) val.toInt();
+		}
+		if (id == "CAD") {									// CAD setting
+			Serial.print(F("CAD=")); Serial.println(val);
+			(*c).cad = (uint8_t) val.toInt();
+		}
+		if (id == "HOP") {									// HOP setting
+			Serial.print(F("HOP=")); Serial.println(val);
+			(*c).hop = (uint8_t) val.toInt();
+		}
+		if (id == "BOOTS") {								// BOOTS setting
+			Serial.print(F("BOOTS=")); Serial.println(val);
+			(*c).boots = (uint8_t) val.toInt();
+		}
+		if (id == "RESETS") {								// RESET setting
+			Serial.print(F("RESETS=")); Serial.println(val);
+			(*c).resets = (uint8_t) val.toInt();
+		}
+		if (id == "WIFIS") {								// WIFIS setting
+			Serial.print(F("WIFIS=")); Serial.println(val);
+			(*c).wifis = (uint8_t) val.toInt();
+		}
+		if (id == "VIEWS") {								// VIEWS setting
+			Serial.print(F("VIEWS=")); Serial.println(val);
+			(*c).views = (uint8_t) val.toInt();
+		}
+		if (id == "NODE") {									// NODE setting
+			Serial.print(F("NODE=")); Serial.println(val);
+			(*c).isNode = (uint8_t) val.toInt();
+		}
+		if (id == "REFR") {									// REFR setting
+			Serial.print(F("REFR=")); Serial.println(val);
+			(*c).refresh = (uint8_t) val.toInt();
+		}
+		if (id == "REENTS") {								// REENTS setting
+			Serial.print(F("REENTS=")); Serial.println(val);
+			(*c).reents = (uint8_t) val.toInt();
+		}
+		if (id == "NTPERR") {								// NTPERR setting
+			Serial.print(F("NTPERR=")); Serial.println(val);
+			(*c).ntpErr = (uint8_t) val.toInt();
+		}
+		if (id == "NTPETIM") {								// NTPERR setting
+			Serial.print(F("NTPETIM=")); Serial.println(val);
+			(*c).ntpErrTime = (uint32_t) val.toInt();
+		}
+		if (id == "NTPS") {									// NTPS setting
+			Serial.print(F("NTPS=")); Serial.println(val);
+			(*c).ntps = (uint8_t) val.toInt();
+		}
+	}
+	f.close();
+	return(1);
+}
+
+// ----------------------------------------------------------------------------
+// Write the current gateway configuration to SPIFFS. First copy all the
+// separate data items to the gwayConfig structure
+//
+// ----------------------------------------------------------------------------
+int writeGwayCfg(const char *fn) {
+
+	gwayConfig.sf = (uint8_t) sf;
+	gwayConfig.ssid = WiFi.SSID();
+	//gwayConfig.pass = WiFi.PASS();					// XXX We should find a way to store the password too
+	gwayConfig.ch = ifreq;
+	gwayConfig.debug = debug;
+	gwayConfig.cad = _cad;
+	gwayConfig.hop = _hop;
+#if GATEWAYNODE==1
+	gwayConfig.fcnt = frameCount;
+#endif
+
+	return(writeConfig(fn, &gwayConfig));
+}
+
+// ----------------------------------------------------------------------------
+// Write the configuration ad found in the espGwayConfig structure
+// to SPIFFS
+// ----------------------------------------------------------------------------
+int writeConfig(const char *fn, struct espGwayConfig *c) {
+
+	if (!SPIFFS.exists(fn)) {
+		Serial.print("WARNING:: writeConfig, file not exists, formatting ");
+		SPIFFS.format();
+		// XXX make all initial declarations here if config vars need to have a value
+		Serial.println(fn);
+	}
+	File f = SPIFFS.open(fn, "w");
+	if (!f) {
+		Serial.print("ERROR:: writeConfig, open file=");
+		Serial.print(fn);
+		Serial.println();
+		return(-1);
+	}
+
+	f.print("SSID"); f.print('='); f.print((*c).ssid); f.print('\n'); 
+	f.print("PASS"); f.print('='); f.print((*c).pass); f.print('\n');
+	f.print("CH"); f.print('='); f.print((*c).ch); f.print('\n');
+	f.print("SF");   f.print('='); f.print((*c).sf);   f.print('\n');
+	f.print("FCNT"); f.print('='); f.print((*c).fcnt); f.print('\n');
+	f.print("DEBUG"); f.print('='); f.print((*c).debug); f.print('\n');
+	f.print("CAD");  f.print('='); f.print((*c).cad); f.print('\n');
+	f.print("HOP");  f.print('='); f.print((*c).hop); f.print('\n');
+	f.print("NODE");  f.print('='); f.print((*c).isNode); f.print('\n');
+	f.print("BOOTS");  f.print('='); f.print((*c).boots); f.print('\n');
+	f.print("RESETS");  f.print('='); f.print((*c).resets); f.print('\n');
+	f.print("WIFIS");  f.print('='); f.print((*c).wifis); f.print('\n');
+	f.print("VIEWS");  f.print('='); f.print((*c).views); f.print('\n');
+	f.print("REFR");  f.print('='); f.print((*c).refresh); f.print('\n');
+	f.print("REENTS");  f.print('='); f.print((*c).reents); f.print('\n');
+	f.print("NTPETIM");  f.print('='); f.print((*c).ntpErrTime); f.print('\n');
+	f.print("NTPERR");  f.print('='); f.print((*c).ntpErr); f.print('\n');
+	f.print("NTPS");  f.print('='); f.print((*c).ntps); f.print('\n');
+	
+	f.close();
+	return(1);
+}

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_loraModem.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_loraModem.ino
@@ -1,0 +1,1453 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+//	and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains the LoRa modem specific code enabling to receive
+// and transmit packages/messages.
+// ========================================================================================
+//
+// STATE MACHINE
+// The program uses the following state machine (in _state), all states
+// are done in interrupt routine, only the follow-up of S-RXDONE is done
+// in the main loop() program. This is because otherwise the interrupt processing
+// would take too long to finish
+//
+// S-INIT=0, 	The commands in this state are executed only once
+//	- Goto S_SCAN
+// S-SCAN, 		CadScanner() part
+//	- upon CDDONE (int0) got S_CAD
+// S-CAD, 		
+//	- Upon CDDECT (int1) goto S_RX, 
+//	- Upon CDDONE (int0) goto S_SCAN
+// S-RX, 		Received CDDECT so message detected, RX cycle started. 
+//	- Upon RXDONE (int0) read ok goto S_RX or S_SCAN, 
+//	- upon RXTOUT (int1) goto S_SCAN
+// S-RXDONE, 	Read the buffer
+//	- Wait for reading in loop()
+//	- Upon message send to server goto S_SCAN
+// S-TX			Transmitting a message
+//	- Upon TX goto S_SCAN
+//
+//
+// SPI AND INTERRUPTS
+// The RFM96/SX1276 communicaties with the ESP8266 by means of interrupts 
+// and SPI interface. The SPI interface is bidirectional and allows both
+// parties to simultaneous write and read to registers.
+// Major drawback is that access is not protected for interrupt and non-
+// interrupt access. This means that when a program in loop() and a program
+// in interrupt do access the readregister and writeRegister() function
+// at teh same time that probably an error will occur.
+// Therefore it is best to Either not use interrupts AT all (like LMIC)
+// or only use these functions in inteerupts and to further processing
+// in the main loop() program.
+//
+// ============================================================================
+
+
+// ----------------------------------------------------------------------------
+// Mutex definitiona
+//
+// ----------------------------------------------------------------------------
+#if MUTEX==1
+	void CreateMutux(int *mutex) {
+		*mutex=1;
+	}
+
+#define LIB_MUTEX 1
+#if LIB_MUTEX==1
+	bool GetMutex(int *mutex) {
+		//noInterrupts();
+		if (*mutex==1) { 
+			*mutex=0; 
+			//interrupts(); 
+			return(true); 
+		}
+		//interrupts();
+		return(false);
+	}
+#else	
+	bool GetMutex(int *mutex) {
+
+	int iOld = 1, iNew = 0;
+
+	asm volatile (
+		"rsil a15, 1\n"    // read and set interrupt level to 1
+		"l32i %0, %1, 0\n" // load value of mutex
+		"bne %0, %2, 1f\n" // compare with iOld, branch if not equal
+		"s32i %3, %1, 0\n" // store iNew in mutex
+		"1:\n"             // branch target
+		"wsr.ps a15\n"     // restore program state
+		"rsync\n"
+		: "=&r" (iOld)
+		: "r" (mutex), "r" (iOld), "r" (iNew)
+		: "a15", "memory"
+	);
+	return (bool)iOld;
+}
+#endif
+
+	void ReleaseMutex(int *mutex) {
+		*mutex=1;
+	}
+	
+#endif //MUTEX==1
+
+// ----------------------------------------------------------------------------
+// Read one byte value, par addr is address
+// Returns the value of register(addr)
+// 
+// The SS (Chip select) pin is used to make sure the RFM95 is selected
+// We also use a volatile mutexSPI to tell use whether the interrupt is in use.
+// The variable is for obvious reasons valid for read and write traffic at the
+// same time. Since both read and write mean that we write to the SPI interface.
+// Parameters:
+//	Address: SPI address to read from. Type unint8_t
+// Return:
+//	Value read from address
+// ----------------------------------------------------------------------------
+
+// define the SPI settings for reading messages
+SPISettings readSettings(SPISPEED, MSBFIRST, SPI_MODE0);
+
+uint8_t readRegister(uint8_t addr)
+{
+	//noInterrupts();								// XXX
+#if MUTEX_SPI==1
+	if(!GetMutex(&mutexSPI)) {
+#if DUSB>=1
+		if (debug>=0) {
+			gwayConfig.reents++;
+			Serial.print(F("readRegister:: read reentry"));
+			printTime();
+			Serial.println();
+			if (debug>=2) Serial.flush();
+			delayMicroseconds(50);
+			initLoraModem();
+		}
+#endif
+		return 0;
+	}
+#endif
+
+	SPI.beginTransaction(readSettings);
+							
+    digitalWrite(pins.ss, LOW);					// Select Receiver
+	SPI.transfer(addr & 0x7F);
+	uint8_t res = (uint8_t) SPI.transfer(0x00);
+    digitalWrite(pins.ss, HIGH);				// Unselect Receiver
+	SPI.endTransaction();
+
+#if MUTEX_SPI==1
+	ReleaseMutex(&mutexSPI);
+#endif
+	//interrupts();								// XXX
+    return((uint8_t) res);
+}
+
+
+// ----------------------------------------------------------------------------
+// Write value to a register with address addr. 
+// Function writes one byte at a time.
+// Parameters:
+//	addr: SPI address to write to
+//	value: The value to write to address
+// Returns:
+//	<void>
+// ----------------------------------------------------------------------------
+
+// define the settings for SPI writing
+SPISettings writeSettings(SPISPEED, MSBFIRST, SPI_MODE0);
+
+void writeRegister(uint8_t addr, uint8_t value)
+{
+	//noInterrupts();							// XXX
+#if MUTEX_SPO==1
+	if(!GetMutex(&mutexSPI)) {
+#if DUSB>=1
+		if (debug>=0) {
+			gwayConfig.reents++;
+			Serial.print(F("writeRegister:: write reentry"));
+			printTime();
+			Serial.println();
+			delayMicroseconds(50);
+			initLoraModem();
+			if (debug>=2) Serial.flush();
+		}
+#endif
+		return;
+	}
+#endif
+	
+	SPI.beginTransaction(writeSettings);
+	digitalWrite(pins.ss, LOW);					// Select Receiver
+	
+	SPI.transfer((addr | 0x80) & 0xFF);
+	SPI.transfer(value & 0xFF);
+	//delayMicroseconds(10);
+	
+    digitalWrite(pins.ss, HIGH);				// Unselect Receiver
+	
+	SPI.endTransaction();
+	
+#if MUTEX_SPO==1
+	ReleaseMutex(&mutexSPI);
+#endif
+	//interrupts();
+}
+
+
+// ----------------------------------------------------------------------------
+// Write a buffer to a register with address addr. 
+// Function writes one byte at a time.
+// Parameters:
+//	addr: SPI address to write to
+//	value: The value to write to address
+// Returns:
+//	<void>
+// ----------------------------------------------------------------------------
+
+void writeBuffer(uint8_t addr, uint8_t *buf, uint8_t len)
+{
+	//noInterrupts();							// XXX
+#if MUTEX_SPO==1
+	if(!GetMutex(&mutexSPI)) {
+#if DUSB>=1
+		if (debug>=0) {
+			gwayConfig.reents++;
+			Serial.print(F("writeBuffer:: write reentry"));
+			printTime();
+			Serial.println();
+			delayMicroseconds(50);
+			initLoraModem();
+			if (debug>=2) Serial.flush();
+		}
+#endif
+		return;
+	}
+#endif
+	
+	SPI.beginTransaction(writeSettings);
+	digitalWrite(pins.ss, LOW);					// Select Receiver
+	
+	SPI.transfer((addr | 0x80) & 0xFF);			// write buffer address
+	for (uint8_t i=0; i<len; i++) {
+		SPI.transfer(buf[i] & 0xFF);
+	}
+    digitalWrite(pins.ss, HIGH);				// Unselect Receiver
+	
+	SPI.endTransaction();
+	
+#if MUTEX_SPI==1
+	ReleaseMutex(&mutexSPI);
+#endif
+	//interrupts();
+}
+
+// ----------------------------------------------------------------------------
+//  setRate is setting rate and spreading factor and CRC etc. for transmission
+//		Modem Config 1 (MC1) == 0x72 for sx1276
+//		Modem Config 2 (MC2) == (CRC_ON) | (sf<<4)
+//		Modem Config 3 (MC3) == 0x04 | (optional SF11/12 LOW DATA OPTIMIZE 0x08)
+//		sf == SF7 default 0x07, (SF7<<4) == SX72_MC2_SF7
+//		bw == 125 == 0x70
+//		cr == CR4/5 == 0x02
+//		CRC_ON == 0x04
+// ----------------------------------------------------------------------------
+
+void setRate(uint8_t sf, uint8_t crc) 
+{
+	uint8_t mc1=0, mc2=0, mc3=0;
+#if DUSB>=2
+	if ((sf<SF7) || (sf>SF12)) {
+		if (debug>=1) {
+			Serial.print(F("setRate:: SF="));
+			Serial.println(sf);
+		}
+		return;
+	}
+#endif
+	// Set rate based on Spreading Factor etc
+    if (sx1272) {
+		mc1= 0x0A;				// SX1276_MC1_BW_250 0x80 | SX1276_MC1_CR_4_5 0x02
+		mc2= ((sf<<4) | crc) % 0xFF;
+		// SX1276_MC1_BW_250 0x80 | SX1276_MC1_CR_4_5 0x02 | SX1276_MC1_IMPLICIT_HEADER_MODE_ON 0x01
+        if (sf == SF11 || sf == SF12) { mc1= 0x0B; }			        
+    } 
+	else {
+	    mc1= 0x72;				// SX1276_MC1_BW_125==0x70 | SX1276_MC1_CR_4_5==0x02
+		mc2= ((sf<<4) | crc) & 0xFF; // crc is 0x00 or 0x04==SX1276_MC2_RX_PAYLOAD_CRCON
+		mc3= 0x04;				// 0x04; SX1276_MC3_AGCAUTO
+        if (sf == SF11 || sf == SF12) { mc3|= 0x08; }		// 0x08 | 0x04
+    }
+	
+	// Implicit Header (IH), for class b beacons (&& SF6)
+	//if (getIh(LMIC.rps)) {
+    //   mc1 |= SX1276_MC1_IMPLICIT_HEADER_MODE_ON;
+    //    writeRegister(REG_PAYLOAD_LENGTH, getIh(LMIC.rps)); // required length
+    //}
+	
+	writeRegister(REG_MODEM_CONFIG1, (uint8_t) mc1);
+	writeRegister(REG_MODEM_CONFIG2, (uint8_t) mc2);
+	writeRegister(REG_MODEM_CONFIG3, (uint8_t) mc3);
+	
+	// Symbol timeout settings
+    if (sf == SF10 || sf == SF11 || sf == SF12) {
+        writeRegister(REG_SYMB_TIMEOUT_LSB, (uint8_t) 0x05);
+    } else {
+        writeRegister(REG_SYMB_TIMEOUT_LSB, (uint8_t) 0x08);
+    }
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+// Set the frequency for our gateway
+// The function has no parameter other than the freq setting used in init.
+// Since we are usin a 1ch gateway this value is set fixed.
+// ----------------------------------------------------------------------------
+
+void  setFreq(uint32_t freq)
+{
+    // set frequency
+    uint64_t frf = ((uint64_t)freq << 19) / 32000000;
+    writeRegister(REG_FRF_MSB, (uint8_t)(frf>>16) );
+    writeRegister(REG_FRF_MID, (uint8_t)(frf>> 8) );
+    writeRegister(REG_FRF_LSB, (uint8_t)(frf>> 0) );
+	
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+//	Set Power for our gateway
+// ----------------------------------------------------------------------------
+void setPow(uint8_t powe)
+{
+	if (powe >= 16) powe = 15;
+	//if (powe >= 15) powe = 14;
+	else if (powe < 2) powe =2;
+	
+	ASSERT((powe>=2)&&(powe<=15));
+	
+	uint8_t pac = (0x80 | (powe & 0xF)) & 0xFF;
+	writeRegister(REG_PAC, (uint8_t)pac);								// set 0x09 to pac
+	
+	// XXX Power settings for CFG_sx1272 are different
+	
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+// Used to set the radio to LoRa mode (transmitter)
+// Please note that this mode can only be set in SLEEP mode and not in Standby.
+// Also there should be not need to re-init this mode is set in the setup() 
+// function.
+// For high freqs (>860 MHz) we need to & with 0x08 otherwise with 0x00
+// ----------------------------------------------------------------------------
+
+//void ICACHE_RAM_ATTR opmodeLora()
+//{
+//#ifdef CFG_sx1276_radio
+//       uint8_t u = OPMODE_LORA | 0x80;   					// TBD: sx1276 high freq 
+//#else // SX-1272
+//	    uint8_t u = OPMODE_LORA | 0x08;
+//#endif
+//    writeRegister(REG_OPMODE, (uint8_t) u);
+//}
+
+
+// ----------------------------------------------------------------------------
+// Set the opmode to a value as defined on top
+// Values are 0x00 to 0x07
+// The value is set for the lowest 3 bits, the other bits are as before.
+// ----------------------------------------------------------------------------
+void  opmode(uint8_t mode)
+{
+	if (mode == OPMODE_LORA) 
+		writeRegister(REG_OPMODE, (uint8_t) mode);
+	else
+		writeRegister(REG_OPMODE, (uint8_t)((readRegister(REG_OPMODE) & ~OPMODE_MASK) | mode));
+}
+
+// ----------------------------------------------------------------------------
+// Hop to next frequency as defined by NUM_HOPS
+// This function should only be used for receiver operation. The current
+// receiver frequency is determined by ifreq index like so: freqs[ifreq] 
+// ----------------------------------------------------------------------------
+void hop() {
+	// If we are already in a hop function, do not proceed
+	if (!inHop) {
+
+		inHop=true;
+		opmode(OPMODE_STANDBY);
+		ifreq = (ifreq + 1)% NUM_HOPS ;
+		setFreq(freqs[ifreq]);
+		hopTime = micros();								// record HOP moment
+		opmode(OPMODE_CAD);
+		inHop=false;
+	}
+#if DUSB>=2
+	else {
+		if (debug >= 3) {
+			Serial.println(F("Hop:: Re-entrance try"));
+		}
+	}
+#endif
+}
+	
+
+// ----------------------------------------------------------------------------
+// This LoRa function reads a message from the LoRa transceiver
+// on Success: returns message length read when message correctly received
+// on Failure: it returns a negative value on error (CRC error for example).
+// UP function
+// This is the "lowlevel" receive function called by stateMachine()
+// dealing with the radio specific LoRa functions
+// ----------------------------------------------------------------------------
+uint8_t receivePkt(uint8_t *payload)
+{
+    uint8_t irqflags = readRegister(REG_IRQ_FLAGS);			// 0x12; read back flags
+
+    cp_nb_rx_rcv++;											// Receive statistics counter
+
+    //  Check for payload IRQ_LORA_CRCERR_MASK=0x20 set
+    if((irqflags & IRQ_LORA_CRCERR_MASK) == IRQ_LORA_CRCERR_MASK)
+    {
+#if DUSB>=2
+        Serial.println(F("CRC"));
+#endif
+		// Reset CRC flag 0x20
+        writeRegister(REG_IRQ_FLAGS, (uint8_t)(IRQ_LORA_CRCERR_MASK || IRQ_LORA_RXDONE_MASK));	// 0x12; clear CRC (== 0x20) flag
+        return 0;
+    }
+	else {
+        cp_nb_rx_ok++;										// Receive OK statistics counter
+
+        uint8_t currentAddr = readRegister(REG_FIFO_RX_CURRENT_ADDR);	// 0x10
+        uint8_t receivedCount = readRegister(REG_RX_NB_BYTES);	// 0x13; How many bytes were read
+#if DUSB>=2
+		if ((debug>=0) && (currentAddr > 64)) {
+			Serial.print(F("receivePkt:: Rx addr>64"));
+			Serial.println(currentAddr);
+			if (debug>=2) Serial.flush();
+		}
+#endif
+        writeRegister(REG_FIFO_ADDR_PTR, (uint8_t) currentAddr);		// 0x0D 
+
+		if (receivedCount > 64) {
+#if DUSB>=2
+			Serial.print(F("receivePkt:: receivedCount="));
+			Serial.println(receivedCount);
+			if (debug>=2) Serial.flush();
+#endif
+			receivedCount=64;
+		}
+#if DUSB>=2
+		else if (debug>=2) {
+			Serial.print(F("ReceivePkt:: addr="));
+			Serial.print(currentAddr);
+			Serial.print(F(", len="));
+			Serial.println(receivedCount);
+			if (debug>=2) Serial.flush();
+		}
+#endif
+        for(int i = 0; i < receivedCount; i++)
+        {
+            payload[i] = readRegister(REG_FIFO);			// 0x00
+        }
+
+		writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);		// Reset ALL interrupts
+		return(receivedCount);
+    }
+	
+	writeRegister(REG_IRQ_FLAGS, (uint8_t) IRQ_LORA_RXDONE_MASK);	// 0x12; Clear RxDone IRQ_LORA_RXDONE_MASK
+    return 0;
+}
+	
+	
+	
+// ----------------------------------------------------------------------------
+// This DOWN function sends a payload to the LoRa node over the air
+// Radio must go back in standby mode as soon as the transmission is finished
+// 
+// NOTE:: writeRegister functions should not be used outside interrupts
+// ----------------------------------------------------------------------------
+bool sendPkt(uint8_t *payLoad, uint8_t payLength)
+{
+#if DUSB>=2
+	if (payLength>=128) {
+		if (debug>=1) {
+			Serial.print("sendPkt:: len=");
+			Serial.println(payLength);
+		}
+		return false;
+	}
+#endif
+	writeRegister(REG_FIFO_ADDR_PTR, (uint8_t) readRegister(REG_FIFO_TX_BASE_AD));	// 0x0D, 0x0E
+	
+	writeRegister(REG_PAYLOAD_LENGTH, (uint8_t) payLength);				// 0x22
+	//for(int i = 0; i < payLength; i++)
+    //{
+    //    writeRegister(REG_FIFO, (uint8_t) payLoad[i]);					// 0x00
+    //}
+	writeBuffer(REG_FIFO, (uint8_t *) payLoad, payLength);
+	return true;
+}
+
+// ----------------------------------------------------------------------------
+// loraWait()
+// This function implements the wait protocol needed for downstream transmissions.
+// Note: Timing of downstream and JoinAccept messages is VERY critical.
+//
+// As the ESP8266 watchdog will not like us to wait more than a few hundred
+// milliseconds (or it will kick in) we have to implement a simple way to wait
+// time in case we have to wait seconds before sending messages (e.g. for OTAA 5 or 6 seconds)
+// Without it, the system is known to crash in half of the cases it has to wait for 
+// JOIN-ACCEPT messages to send.
+//
+// This function uses a combination of delay() statements and delayMicroseconds().
+// As we use delay() only when there is still enough time to wait and we use micros()
+// to make sure that delay() did not take too much time this works.
+// 
+// Parameter: uint32-t tmst gives the micros() value when transmission should start.
+// ----------------------------------------------------------------------------
+
+void loraWait(uint32_t tmst)
+{
+	uint32_t startTime = micros();						// Start of the loraWait function
+	tmst += txDelay;
+	uint32_t waitTime = tmst - micros();
+		
+	while (waitTime > 16000) {
+		delay(15);										// ms delay including yield, slightly shorter
+		waitTime= tmst - micros();
+	}
+	if (waitTime>0) delayMicroseconds(waitTime);
+#if DUSB>=2
+	else if ((waitTime+20) < 0) {
+		Serial.println(F("loraWait TOO LATE"));
+	}
+	
+	if (debug >=1) { 
+		Serial.print(F("start: ")); 
+		Serial.print(startTime);
+		Serial.print(F(", end: "));
+		Serial.print(tmst);
+		Serial.print(F(", waited: "));
+		Serial.print(tmst - startTime);
+		Serial.print(F(", delay="));
+		Serial.print(txDelay);
+		Serial.println();
+		if (debug>=2) Serial.flush();
+	}
+#endif
+}
+
+
+// ----------------------------------------------------------------------------
+// txLoraModem
+// Init the transmitter and transmit the buffer
+// After successful transmission (dio0==1) TxDone re-init the receiver
+//
+//	crc is set to 0x00 for TX
+//	iiq is set to 0x27 (or 0x40 based on ipol value in txpkt)
+//
+//	1. opmode Lora (only in Sleep mode)
+//	2. opmode StandBY
+//	3. Configure Modem
+//	4. Configure Channel
+//	5. write PA Ramp
+//	6. config Power
+//	7. RegLoRaSyncWord LORA_MAC_PREAMBLE
+//	8. write REG dio mapping (dio0)
+//	9. write REG IRQ flags
+// 10. write REG IRQ mask
+// 11. write REG LoRa Fifo Base Address
+// 12. write REG LoRa Fifo Addr Ptr
+// 13. write REG LoRa Payload Length
+// 14. Write buffer (byte by byte)
+// 15. Wait until the right time to transmit has arrived
+// 16. opmode TX
+// ----------------------------------------------------------------------------
+
+void txLoraModem(uint8_t *payLoad, uint8_t payLength, uint32_t tmst, uint8_t sfTx,
+						uint8_t powe, uint32_t freq, uint8_t crc, uint8_t iiq)
+{
+#if DUSB>=2
+	if (debug>=1) {
+		// Make sure that all serial stuff is done before continuing
+		Serial.print(F("txLoraModem::"));
+		Serial.print(F("  powe: ")); Serial.print(powe);
+		Serial.print(F(", freq: ")); Serial.print(freq);
+		Serial.print(F(", crc: ")); Serial.print(crc);
+		Serial.print(F(", iiq: 0X")); Serial.print(iiq,HEX);
+		Serial.println();
+		if (debug>=2) Serial.flush();
+	}
+#endif
+	_state = S_TX;
+		
+	// 1. Select LoRa modem from sleep mode
+	//opmode(OPMODE_LORA);									// set register 0x01 to 0x80
+	
+	// Assert the value of the current mode
+	ASSERT((readRegister(REG_OPMODE) & OPMODE_LORA) != 0);
+	
+	// 2. enter standby mode (required for FIFO loading))
+	opmode(OPMODE_STANDBY);									// set 0x01 to 0x01
+	
+	// 3. Init spreading factor and other Modem setting
+	setRate(sfTx, crc);
+	
+	// Frquency hopping
+	//writeRegister(REG_HOP_PERIOD, (uint8_t) 0x00);		// set 0x24 to 0x00 only for receivers
+	
+	// 4. Init Frequency, config channel
+	setFreq(freq);
+
+	// 6. Set power level, REG_PAC
+	setPow(powe);
+	
+	// 7. prevent node to node communication
+	writeRegister(REG_INVERTIQ, (uint8_t) iiq);						// 0x33, (0x27 or 0x40)
+	
+	// 8. set the IRQ mapping DIO0=TxDone DIO1=NOP DIO2=NOP (or lesss for 1ch gateway)
+    writeRegister(REG_DIO_MAPPING_1, (uint8_t)(MAP_DIO0_LORA_TXDONE|MAP_DIO1_LORA_NOP|MAP_DIO2_LORA_NOP));
+	
+	// 9. clear all radio IRQ flags
+    writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);
+	
+	// 10. mask all IRQs but TxDone
+    writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) ~IRQ_LORA_TXDONE_MASK);
+	
+	// txLora
+	opmode(OPMODE_FSTX);									// set 0x01 to 0x02 (actual value becomes 0x82)
+	
+	// 11, 12, 13, 14. write the buffer to the FiFo
+	sendPkt(payLoad, payLength);
+
+	// 15. wait extra delay out. The delayMicroseconds timer is accurate until 16383 uSec.
+	loraWait(tmst);
+	
+	//Set the base addres of the transmit buffer in FIFO
+    writeRegister(REG_FIFO_ADDR_PTR, (uint8_t) readRegister(REG_FIFO_TX_BASE_AD));	// set 0x0D to 0x0F (contains 0x80);	
+	
+	//For TX we have to set the PAYLOAD_LENGTH
+    writeRegister(REG_PAYLOAD_LENGTH, (uint8_t) payLength);		// set 0x22, max 0x40==64Byte long
+	
+	//For TX we have to set the MAX_PAYLOAD_LENGTH
+    writeRegister(REG_MAX_PAYLOAD_LENGTH, (uint8_t) MAX_PAYLOAD_LENGTH);	// set 0x22, max 0x40==64Byte long
+	
+	// Reset the IRQ register
+	//writeRegister(REG_IRQ_FLAGS, 0xFF);						// set 0x12 to 0xFF
+	writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);			// Clear the mask
+	writeRegister(REG_IRQ_FLAGS, (uint8_t) IRQ_LORA_TXDONE_MASK);// set 0x12 to 0x08
+	
+	// 16. Initiate actual transmission of FiFo
+	opmode(OPMODE_TX);											// set 0x01 to 0x03 (actual value becomes 0x83)
+	
+}// txLoraModem
+
+
+// ----------------------------------------------------------------------------
+// Setup the LoRa receiver on the connected transceiver.
+// - Determine the correct transceiver type (sx1272/RFM92 or sx1276/RFM95)
+// - Set the frequency to listen to (1-channel remember)
+// - Set Spreading Factor (standard SF7)
+// The reset RST pin might not be necessary for at least the RGM95 transceiver
+//
+// 1. Put the radio in LoRa mode
+// 2. Put modem in sleep or in standby
+// 3. Set Frequency
+// 4. Spreading Factor
+// 5. Set interrupt mask
+// 6. Clear all interrupt flags
+// 7. Set opmode to OPMODE_RX
+// 8. Set _state to S_RX
+// 9. Reset all interrupts
+// ----------------------------------------------------------------------------
+
+void rxLoraModem()
+{
+	// 1. Put system in LoRa mode
+	//opmode(OPMODE_LORA);
+	
+	// 2. Put the radio in sleep mode
+	opmode(OPMODE_STANDBY);
+    //opmode(OPMODE_SLEEP);										// set 0x01 to 0x00
+	
+	// 3. Set frequency based on value in freq
+	setFreq(freqs[ifreq]);										// set to 868.1MHz
+
+	// 4. Set spreading Factor and CRC
+    setRate(sf, 0x04);
+	
+	// prevent node to node communication
+	writeRegister(REG_INVERTIQ, (uint8_t) 0x27);				// 0x33, 0x27; to reset from TX
+	
+	// Max Payload length is dependent on 256 byte buffer. 
+	// At startup TX starts at 0x80 and RX at 0x00. RX therefore maximized at 128 Bytes
+	//For TX we have to set the PAYLOAD_LENGTH
+    //writeRegister(REG_PAYLOAD_LENGTH, (uint8_t) PAYLOAD_LENGTH);	// set 0x22, 0x40==64Byte long
+
+	// Set CRC Protection or MAX payload protection
+    //writeRegister(REG_MAX_PAYLOAD_LENGTH, (uint8_t) MAX_PAYLOAD_LENGTH);	// set 0x23 to 0x80==128
+	
+	//Set the start address for the FiFO (Which should be 0)
+    writeRegister(REG_FIFO_ADDR_PTR, (uint8_t) readRegister(REG_FIFO_RX_BASE_AD));	// set 0x0D to 0x0F (contains 0x00);
+	
+    // Low Noise Amplifier used in receiver
+    writeRegister(REG_LNA, (uint8_t) LNA_MAX_GAIN);  						// 0x0C, 0x23
+	
+	// Accept no interrupts except RXDONE, RXTOUT en RXCRC
+	writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) ~(IRQ_LORA_RXDONE_MASK | IRQ_LORA_RXTOUT_MASK | IRQ_LORA_CRCERR_MASK));
+
+	// set frequency hopping
+	if (_hop) {
+#if DUSB>=1
+		if (debug >= 1) { 
+			Serial.print(F("rxLoraModem:: Hop, channel=")); 
+			Serial.println(ifreq); 
+		}
+#endif
+		writeRegister(REG_HOP_PERIOD, 0x01);					// 0x24, 0x01 was 0xFF
+		// Set RXDONE interrupt to dio0
+		writeRegister(REG_DIO_MAPPING_1, (uint8_t)(MAP_DIO0_LORA_RXDONE | MAP_DIO1_LORA_RXTOUT | MAP_DIO1_LORA_FCC));
+	}
+	else {
+		writeRegister(REG_HOP_PERIOD,0x00);						// 0x24, 0x00 was 0xFF
+		// Set RXDONE interrupt to dio0
+		writeRegister(REG_DIO_MAPPING_1, (uint8_t)(MAP_DIO0_LORA_RXDONE | MAP_DIO1_LORA_RXTOUT));
+	}
+	
+
+	// Set the opmode to either single or continuous receive. The first is used when
+	// every message can come on a different SF, the second when we have fixed SF
+	if (_cad) {
+		// cad Scanner setup, set _state to S_RX
+		// Set Single Receive Mode, goes in STANDBY mode after receipt
+		_state = S_RX;
+		opmode(OPMODE_RX_SINGLE);								// 0x80 | 0x06 (listen one message)
+	}
+	else {
+		// Set Continous Receive Mode, usefull if we stay on one SF
+		_state= S_RX;
+		opmode(OPMODE_RX);										// 0x80 | 0x05 (listen)
+	}
+	
+	// 9. clear all radio IRQ flags
+    writeRegister(REG_IRQ_FLAGS, 0xFF);
+	
+	return;
+}// rxLoraModem
+
+
+// ----------------------------------------------------------------------------
+// function cadScanner()
+//
+// CAD Scanner will scan on the given channel for a valid Symbol/Preamble signal.
+// So instead of receiving continuous on a given channel/sf combination
+// we will wait on the given channel and scan for a preamble. Once received
+// we will set the radio to the SF with best rssi (indicating reception on that sf).
+// The function sets the _state to S_SCAN
+// NOTE: DO not set the frequency here but use the frequency hopper
+// ----------------------------------------------------------------------------
+void cadScanner()
+{
+	// 1. Put system in LoRa mode (which destroys all other nodes(
+	//opmode(OPMODE_LORA);
+	
+	// 2. Put the radio in sleep mode
+	opmode(OPMODE_STANDBY);										// Was old value
+	//opmode(OPMODE_SLEEP);										// set 0x01 to 0x00
+	
+	// As we can come back from S_TX with other frequencies and SF
+	// reset both to good values for cadScanner
+	
+	// 3. Set frequency based on value in freq					// XXX New, might be needed when receiving down
+#if DUSB>=2
+	if ((debug>=1) && (ifreq>9)) {
+		Serial.print(F("cadScanner:: E Freq="));
+		Serial.println(ifreq);
+		if (debug>=2) Serial.flush();
+		ifreq=0;
+	}
+#endif
+	setFreq(freqs[ifreq]);
+
+	// For every time we stat the scanner, we set the SF to the begin value
+	sf = SF7;													// we make SF the lower, this is faster!
+	
+	// 4. Set spreading Factor and CRC
+	setRate(sf, 0x04);
+	
+	// listen to LORA_MAC_PREAMBLE
+	writeRegister(REG_SYNC_WORD, (uint8_t) 0x34);				// set reg 0x39 to 0x34
+	
+	// Set the interrupts we want top listen to
+	writeRegister(REG_DIO_MAPPING_1,
+		(uint8_t)(MAP_DIO0_LORA_CADDONE | MAP_DIO1_LORA_CADDETECT | MAP_DIO2_LORA_NOP | MAP_DIO3_LORA_NOP));
+	
+	// Set the mask for interrupts (we do not want to listen to) except for
+	writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) ~(IRQ_LORA_CDDONE_MASK | IRQ_LORA_CDDETD_MASK | IRQ_LORA_CRCERR_MASK));
+	
+	// Set the opMode to CAD
+	opmode(OPMODE_CAD);
+
+	// Clear all relevant interrupts
+	//writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF );						// May work better, clear ALL interrupts
+	
+	// If we are here. we either might have set the SF or we have a timeout in which
+	// case the receive is started just as normal.
+	return;
+}// cadScanner
+
+
+// ----------------------------------------------------------------------------
+// First time initialisation of the LoRa modem
+// Subsequent changes to the modem state etc. done by txLoraModem or rxLoraModem
+// After initialisation the modem is put in rx mode (listen)
+// ----------------------------------------------------------------------------
+void initLoraModem()
+{
+	_state = S_INIT;
+	// Reset the transceiver chip with a pulse of 10 mSec
+#ifdef ESP32BUILD
+	digitalWrite(pins.rst, LOW);
+	delayMicroseconds(10000);
+  digitalWrite(pins.rst, HIGH);
+	delayMicroseconds(10000);
+#else
+  digitalWrite(pins.rst, HIGH);
+  delayMicroseconds(10000);
+  digitalWrite(pins.rst, LOW);
+  delayMicroseconds(10000);
+#endif
+  digitalWrite(pins.ss, HIGH);
+
+  // Check chip version first
+    uint8_t version = readRegister(REG_VERSION);        // Read the LoRa chip version id
+    if (version == 0x22) {
+        // sx1272
+#if DUSB>=2
+        Serial.println(F("WARNING:: SX1272 detected"));
+#endif
+        sx1272 = true;
+    } 
+  else if (version == 0x12) {
+        // sx1276?
+#if DUSB>=2
+            if (debug >=1) 
+        Serial.println(F("SX1276 starting"));
+#endif
+            sx1272 = false;
+  } 
+  else {
+#if DUSB>=2
+    Serial.print(F("Unknown transceiver="));
+    Serial.println(version,HEX);
+#endif
+    die("");
+    }
+
+	// 2. Set radio to sleep
+	opmode(OPMODE_SLEEP);										// set register 0x01 to 0x00
+
+	// 1 Set LoRa Mode
+	opmode(OPMODE_LORA);										// set register 0x01 to 0x80
+	
+	// 3. Set frequency based on value in freq
+	ifreq = 0; 
+	freq=freqs[0];
+	setFreq(freq);												// set to 868.1MHz
+	
+	// 4. Set spreading Factor
+    setRate(sf, 0x04);
+	
+	// Low Noise Amplifier used in receiver
+    writeRegister(REG_LNA, (uint8_t) LNA_MAX_GAIN);  						// 0x0C, 0x23
+	
+	// 7. set sync word
+    writeRegister(REG_SYNC_WORD, (uint8_t) 0x34);				// set 0x39 to 0x34 LORA_MAC_PREAMBLE
+	
+	// prevent node to node communication
+	writeRegister(REG_INVERTIQ,0x27);							// 0x33, 0x27; to reset from TX
+	
+	// Max Payload length is dependent on 256 byte buffer. At startup TX starts at
+	// 0x80 and RX at 0x00. RX therefore maximized at 128 Bytes
+    writeRegister(REG_MAX_PAYLOAD_LENGTH,MAX_PAYLOAD_LENGTH);	// set 0x23 to 0x80==128 bytes
+    writeRegister(REG_PAYLOAD_LENGTH,PAYLOAD_LENGTH);			// 0x22, 0x40==64Byte long
+	
+    writeRegister(REG_FIFO_ADDR_PTR, readRegister(REG_FIFO_RX_BASE_AD));	// set reg 0x0D to 0x0F
+	writeRegister(REG_HOP_PERIOD,0x00);							// reg 0x24, set to 0x00 was 0xFF
+	if (_hop) {
+		writeRegister(REG_HOP_CHANNEL,0x00);					// reg 0x1C, set to 0x00
+	}
+
+	// 5. Config PA Ramp up time								// set reg 0x0A  
+	writeRegister(REG_PARAMP, (readRegister(REG_PARAMP) & 0xF0) | 0x08); // set PA ramp-up time 50 uSec
+	
+	// Set 0x4D PADAC for SX1276 ; XXX register is 0x5a for sx1272
+	writeRegister(REG_PADAC_SX1276,  0x84); 					// set 0x4D (PADAC) to 0x84
+	//writeRegister(REG_PADAC, readRegister(REG_PADAC)|0x4);
+	
+	// Reset interrupt Mask, enable all interrupts
+	writeRegister(REG_IRQ_FLAGS_MASK, 0x00);
+	
+	// 9. clear all radio IRQ flags
+    writeRegister(REG_IRQ_FLAGS, 0xFF);
+}// initLoraModem
+
+
+
+// ----------------------------------------------------------------------------
+// stateMachine handler of the state machine.
+// We use ONE state machine for all kind of interrupts. This assures that we take
+// the correct action upon receiving an interrupt.
+//
+// STATE MACHINE
+// The program uses the following state machine (in _state), all states
+// are done in interrupt routine, only the follow-up of S-RXDONE is done
+// in the main loop() program. This is because otherwise the interrupt processing
+// would take too long to finish
+//
+// S-INIT=0, 	The commands in this state are executed only once
+//	- Goto S_SCAN
+//
+// S-SCAN, 		CadScanner() part
+//	- Upon CDDECT (int1) goto S_RX, 
+//	- upon CDDONE (int0) got S_CAD, walk through all SF until CDDETD
+//	- Else stay in SCAN state
+//
+// S-CAD, 		
+//	- Upon CDDECT (int1) goto S_RX, 
+//	- Upon CDDONE (int0) goto S_SCAN, start with SF7 recognition again
+//
+// S-RX, 		Received CDDECT so message detected, RX cycle started. 
+//	- Upon RXDONE (int0) package read. If read ok continue, 
+//	- upon RXTOUT (int1) goto S_SCAN
+//
+// S-RXDONE Buffer reading is complete
+//	- Wait for reading in loop()
+//	- Upon message send to server goto S_SCAN
+//
+// S-TX			Transmitting a message
+//	- Upon TX goto S_SCAN
+//
+// S-TXDONE		Transmission complete by loop() now again in interrupt
+//	- Set the Mask
+//	- reset the Flags
+//	- Goto either SCAN or RX
+//
+// This interrupt routine has been kept as simple and short as possible.
+// If we receive an interrupt that does not below to a _state then print error.
+// 
+// NOTE: We may clear the interrupt but leave the flag for the moment. 
+//	The eventHandler should take care of repairing flags between interrupts.
+// ----------------------------------------------------------------------------
+
+void stateMachine()
+{
+	// Make a sort of mutex by using a volatile variable
+#if MUTEX_INT==1	
+	if(!GetMutex(&inIntr)) {
+#if DUSB>=1
+		if (debug>=0) {
+			Serial.println(F("eInt:: Mutex"));
+			if (debug>=2) Serial.flush();
+		}
+#endif
+		return;
+	}
+#endif
+	// Determine what interrupt flags are set
+	uint8_t flags = readRegister(REG_IRQ_FLAGS);
+	uint8_t mask  = readRegister(REG_IRQ_FLAGS_MASK);
+	uint8_t intr  = flags & ( ~ mask );				// Only react on non masked interrupts
+	uint8_t rssi;
+	
+	if (intr == 0x00) {
+#if DUSB>=1
+		// Something strange has happened: There has been an event
+		// and we do not have a value for interrupt.
+		if (debug>=1) Serial.println(F("stateMachine:: NO intr"));
+#endif
+
+		// Mayby wait a little before resetting all/
+#if MUTEX_INT==1
+		ReleaseMutex(&inIntr);
+#endif		
+		//_state = S_SCAN;
+		writeRegister(REG_IRQ_FLAGS, 0xFF );		// Clear ALL interrupts
+		_event = 0;
+		return;
+	}
+	
+	// Small state machine inside the interrupt handler
+	// as next actions are depending on the state we are in.
+	switch (_state) 
+	{
+	
+	  // --------------------------------------------------------------
+	  // If the state is init, we are starting up.
+	  // The initLoraModem() function is already called ini setup();
+	  case S_INIT:
+#if DUSB>=2
+		if (debug >= 1) { 
+			Serial.println(F("S_INIT")); 
+		}
+#endif
+		// new state, needed to startup the radio (to S_SCAN)
+		writeRegister(REG_IRQ_FLAGS, 0xFF );		// Clear ALL interrupts
+	  break;
+
+	  
+	  // --------------------------------------------------------------
+	  // In S_SCAN we measure a high RSSI this means that there (probably) is a message
+	  // coming in at that freq. But not necessarily on the current SF.
+	  // If so find the right SF with CDDETD. 
+	  case S_SCAN:
+	    //
+		// Intr=IRQ_LORA_CDDETD_MASK
+		// We detected a message on this frequency and SF when scanning
+		// We clear both CDDETD and CDDONE and swich to reading state
+		//
+		if (intr & IRQ_LORA_CDDETD_MASK) {
+#if DUSB>=2
+			if (debug >=3) {
+				Serial.println(F("SCAN:: CADDETD, "));
+			}
+#endif
+
+			_state = S_RX;								// Set state to receiving
+			opmode(OPMODE_RX_SINGLE);					// set reg 0x01 to 0x06
+
+			// Set RXDONE interrupt to dio0, RXTOUT to dio1
+			writeRegister(REG_DIO_MAPPING_1, (MAP_DIO0_LORA_RXDONE | MAP_DIO1_LORA_RXTOUT));
+			
+			// Since new state is S_RX, accept no interrupts except RXDONE or RXTOUT		
+			writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) ~(IRQ_LORA_RXDONE_MASK | IRQ_LORA_RXTOUT_MASK));
+			
+			delayMicroseconds( RSSI_WAIT_DOWN );		// Wait some microseconds less
+			// Starting with version 5.0.1 the waittime is dependent on the SF
+			// So for SF12 we wait longer (2^7 == 128 uSec) and for SF7 4 uSec.
+			//delayMicroseconds( (0x01 << ((uint8_t)sf - 5 )) );
+			rssi = readRegister(REG_RSSI);				// Read the RSSI
+			_rssi = rssi;								// Read the RSSI in the state variable
+
+			writeRegister(REG_IRQ_FLAGS, 0xFF );		// reset all interrupt flags
+		}//if
+
+		// CDDONE
+		// We received a CDDONE int telling us that we received a message on this
+		// frequency and possibly on one of its SF.
+		// If so, we switch to CAD state where we will only listen to CDDETD event.
+		//
+		else if (intr & IRQ_LORA_CDDONE_MASK) {
+
+			opmode(OPMODE_CAD);
+		
+			rssi = readRegister(REG_RSSI);				// Read the RSSI
+
+			// We choose the generic RSSI as a sorting mechanism for packages/messages
+			// The pRSSI (package RSSI) is caluclated upon successful reception of message
+			// So we expect tht this value makes little sense for the moment with CDDONE.
+			// Set the rssi as low as the noise floor. Lower values are not recognized then.
+			//
+			if ( rssi > RSSI_LIMIT ) {					// Is set to 37 (27/08/2017)
+				_state = S_CAD;							// XXX invoke the interrupt handler again?
+			}
+
+			// Clear the CADDONE flag
+			//writeRegister(REG_IRQ_FLAGS, IRQ_LORA_CDDONE_MASK);
+			writeRegister(REG_IRQ_FLAGS, 0xFF);
+		}
+		
+		// If not CDDETC and not CDDONE and sf==12 we have to hop
+		else if ((_hop) && (sf==12)) {
+				hop();
+				sf=(sf_t)7;
+		}
+		
+		// If we do not switch to S_CAD, we have to hop
+		// Instead of waiting for an interrupt we do this on timer basis (more regular).
+		else {
+			_state=S_SCAN;
+			cadScanner();
+			writeRegister(REG_IRQ_FLAGS, 0xFF);
+		}
+		// else keep on scanning
+	  break; // S_SCAN
+
+	  
+	  // --------------------------------------------------------------
+	  // S_CAD: In CAD mode we scan every SF for high RSSI until we have a DETECT.
+	  // Reason is the we received a CADDONE interrupt so we know a message is received
+	  // on the frequency but may be on another SF.
+	  //
+	  // If message is of the right frequency and SF, IRQ_LORA_CDDETD_MSAK interrupt
+	  // is raised, indicating that we can start beging reading the message from SPI.
+	  //
+	  // DIO0 interrupt IRQ_LORA_CDDONE_MASK in state S_CAD==2 means that we might have
+	  // a lock on the Freq but not the right SF. So we increase the SF
+	  //
+	  case S_CAD:
+
+		// Intr=IRQ_LORA_CDDETD_MASK
+		// We have to set the sf based on a strong RSSI for this channel
+		//
+		if (intr & IRQ_LORA_CDDETD_MASK) {
+
+			_state = S_RX;								// Set state to start receiving
+			opmode(OPMODE_RX_SINGLE);					// set reg 0x01 to 0x06, initiate READ
+			
+			// Set RXDONE interrupt to dio0, RXTOUT to dio1
+			writeRegister(REG_DIO_MAPPING_1, (MAP_DIO0_LORA_RXDONE | MAP_DIO1_LORA_RXTOUT));
+			
+			// Accept no interrupts except RXDONE or RXTOUT
+			writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) ~(IRQ_LORA_RXDONE_MASK | IRQ_LORA_RXTOUT_MASK));
+
+			delayMicroseconds( RSSI_WAIT_DOWN );		// Wait some microseconds less
+			//delayMicroseconds( (0x01 << ((uint8_t)sf - 5 )) );
+			rssi = readRegister(REG_RSSI);				// Read the RSSI
+			_rssi = rssi;								// Read the RSSI in the state variable
+
+			//writeRegister(REG_IRQ_FLAGS, IRQ_LORA_CDDETD_MASK | IRQ_LORA_RXDONE_MASK);
+			writeRegister(REG_IRQ_FLAGS, 0xFF );		// reset all CAD Detect interrupt flags
+		}// CDDETD
+		
+		// Intr == CADDONE
+		// So we scan this SF and if not high enough ... next
+		//
+		else if (intr & IRQ_LORA_CDDONE_MASK) {
+			// If this is not SF12, increment the SF and try again
+			// We expect on other SF get CDDETD
+			//
+			if (((uint8_t)sf) < SF12) {
+				sf = (sf_t)((uint8_t)sf+1);				// XXX This would mean SF7 never used
+				setRate(sf, 0x04);						// Set SF with CRC==on
+
+				opmode(OPMODE_CAD);						// Scanning mode
+				
+				delayMicroseconds(RSSI_WAIT );
+				rssi = readRegister(REG_RSSI);			// Read the RSSI
+				
+				// reset interrupt flags for CAD Done
+				writeRegister(REG_IRQ_FLAGS, IRQ_LORA_CDDONE_MASK | IRQ_LORA_CDDETD_MASK);
+				//writeRegister(REG_IRQ_FLAGS, 0xFF );	// XXX this will prevent the CDDETD from being read
+				
+			}
+			// If we reach SF12, we should go back to SCAN state
+			else {
+				if (_hop) { hop(); }					// if HOP we start at the next frequency
+				_state = S_SCAN;
+				cadScanner();							// Which will reset SF to SF7
+				// Reset the interrupts
+				writeRegister(REG_IRQ_FLAGS, IRQ_LORA_CDDONE_MASK);
+			}
+		} //CADDONE
+
+		//
+		// if this interrupt is not CDECT or CDDONE then the interrupt is
+		// is unknown in this state. So we clear interrupt and give a warning.
+		else {
+#if DUSB>=2
+			if (debug>=1) { 
+				Serial.println(F("CAD:: Unknown interrupt")); 
+			}
+#endif
+			_state = S_SCAN;
+			cadScanner();
+			writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);			// Reset all interrupts
+		}
+	  break; //S_CAD
+
+	  
+	  // --------------------------------------------------------------
+	  // If we receive an interrupt on dio0 state==S_RX
+	  // it should be a RxDone interrupt
+	  // So we should handle the received message
+	  case S_RX:
+	
+		if (intr & IRQ_LORA_RXDONE_MASK) {
+
+			// We have to check for CRC error which will be visible AFTER RXDONE is set.
+			// CRC errors might indicate tha the reception is not OK.
+			// Could be CRC error or message too large.
+			// CRC error checking requires DIO3
+			if (intr & IRQ_LORA_CRCERR_MASK) {
+#if DUSB>=2
+				Serial.println(F("CRC err"));
+				if (debug>=2) Serial.flush();
+#endif
+				if (_cad) {
+					_state = S_SCAN;
+					cadScanner();
+				}
+				else {
+					_state = S_RX;
+					rxLoraModem();
+				}
+				
+				writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);	// Reset the interrupt mask
+				// Reset interrupts
+				writeRegister(REG_IRQ_FLAGS, (uint8_t)(IRQ_LORA_CRCERR_MASK | IRQ_LORA_RXDONE_MASK | IRQ_LORA_RXTOUT_MASK));
+				break;
+			}
+
+			if((LoraUp.payLength = receivePkt(LoraUp.payLoad)) <= 0) {
+#if DUSB>=1
+				if (debug>=0) {
+					Serial.println(F("sMachine:: Error S-RX"));
+				}
+#endif
+			}
+				
+			// Do all register processing in this section (interrupt)
+			uint8_t value = readRegister(REG_PKT_SNR_VALUE);	// 0x19; 
+			if( value & 0x80 ) {								// The SNR sign bit is 1
+				
+				value = ( ( ~value + 1 ) & 0xFF ) >> 2;			// Invert and divide by 4
+				LoraUp.snr = -value;
+			}
+			else {
+				// Divide by 4
+				LoraUp.snr = ( value & 0xFF ) >> 2;
+			}
+	
+			LoraUp.prssi = readRegister(REG_PKT_RSSI);			// read register 0x1A, packet rssi
+    
+			// Correction of RSSI value based on chip used.	
+			if (sx1272) {										// Is it a sx1272 radio?
+				LoraUp.rssicorr = 139;
+			} else {											// Probably SX1276 or RFM95
+				LoraUp.rssicorr = 157;
+			}
+				
+			LoraUp.sf = readRegister(REG_MODEM_CONFIG2) >> 4;
+
+			if (receivePacket() <= 0) {							// read is not successful
+#if DUSB>=1
+				Serial.println(F("sMach:: Error receivePacket"));
+#endif
+			}
+#if DUSB>=2
+			else if (debug>=2) {
+				Serial.println(F("sMach:: receivePacket OK"));
+			}
+#endif
+			
+			// Set the modem to receiving BEFORE going back to
+			// user space.
+			if (_cad) {
+				_state = S_SCAN;
+				cadScanner();
+			}
+			else {
+				_state = S_RX;
+				rxLoraModem();
+			}
+			
+			writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);
+			writeRegister(REG_IRQ_FLAGS, 0xFF);			// Reset the interrupt mask
+		}
+		
+		// Receive message timeout
+		else if (intr & IRQ_LORA_RXTOUT_MASK) {
+			
+			// Set the modem for next receive action. This must be done before
+			// scanning takes place as we cannot do it once RXDETTD is set.
+			
+			if (_cad) {
+				// Set the state to CAD scanning
+				_state = S_SCAN;
+				cadScanner();							// Start the scanner after RXTOUT
+			}
+			else {
+				_state = S_RX;							// XXX 170828, why?
+				rxLoraModem();			
+			}
+			writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00 );
+			writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);			// reset all interrupts
+		}
+
+		// The interrupt received is not RXDONE nor RXTOUT
+		// therefore we restart the scanning sequence (catch all)
+		else {
+#if DUSB>=2
+			if (debug >=3) {
+				Serial.println(F("S_RX:: No RXDONE/RXTOUT, "));
+			}
+#endif
+			initLoraModem();							// Reset all communication,3
+			if (_cad) {
+				_state = S_SCAN;
+				cadScanner();
+			}
+			else {
+				_state = S_RX;
+				rxLoraModem();			
+			}
+			writeRegister(REG_IRQ_FLAGS_MASK, 0x00);	// Reset all masks
+			writeRegister(REG_IRQ_FLAGS, 0xFF);			// Reset all interrupts
+		}
+	  break; // S_RX
+
+	  
+	  // --------------------------------------------------------------  
+
+	  //
+	  case S_TX:
+	  
+	  	// Initiate the transmission of the buffer (in Interrupt space)
+		// We react on ALL interrupts if we are in TX state.
+		
+		txLoraModem(
+			LoraDown.payLoad,
+			LoraDown.payLength,
+			LoraDown.tmst,
+			LoraDown.sfTx,
+			LoraDown.powe,
+			LoraDown.fff,
+			LoraDown.crc,
+			LoraDown.iiq
+		);
+		
+#if DUSB>=2
+		if (debug>=0) { 
+			Serial.println(F("S_TX, ")); 
+		}
+#endif
+		_state = S_TXDONE;
+		writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);
+		writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);				// reset interrupt flags
+		
+	  break; // S_TX
+	  
+	  // ---------------------------------------------------
+	  // AFter the transmission is completed by the hardware, 
+	  // the interrupt TXDONE is raised telling us that the tranmission
+	  // was successful.
+	  // If we receive an interrupt on dio0 _state==S_TX it is a TxDone interrupt
+	  // Do nothing with the interrupt, it is just an indication.
+	  // sendPacket switch back to scanner mode after transmission finished OK
+	  case S_TXDONE:
+		if (intr & IRQ_LORA_TXDONE_MASK) {
+#if DUSB>=1
+			Serial.println(F("TXDONE interrupt"));
+#endif
+			// After transmission reset to receiver
+			if (_cad) {
+				// Set the state to CAD scanning
+				_state = S_SCAN;
+				cadScanner();								// Start the scanner after TX cycle
+			}
+			else {
+				_state = S_RX;
+				rxLoraModem();		
+			}
+		
+			writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);
+			writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);				// reset interrupt flags
+#if DUSB>=1
+			if (debug>=1) {
+				Serial.println(F("TXDONE handled"));
+				if (debug>=2) Serial.flush();
+			}
+#endif
+		}
+		else {
+#if DUSB>=1
+			if (debug>=0) {
+				Serial.println(F("TXDONE unknown interrupt"));
+				if (debug>=2) Serial.flush();
+			}
+#endif
+		}
+	  break; // S_TXDONE	  
+
+	  
+	  // --------------------------------------------------------------
+	  // If _STATE is in undefined state
+	  // If such a thing happens, we should re-init the interface and 
+	  // make sure that we pick up next interrupt
+	  default:
+#if DUSB>=2
+		if (debug >= 2) { 
+			Serial.print("E state="); 
+			Serial.println(_state);	
+		}
+#endif
+		if (_cad) {
+			_state = S_SCAN;
+			cadScanner();
+		}
+		else
+		{
+			_state = S_RX;
+			rxLoraModem();
+		}
+		writeRegister(REG_IRQ_FLAGS_MASK, (uint8_t) 0x00);
+		writeRegister(REG_IRQ_FLAGS, (uint8_t) 0xFF);				// Reset all interrupts
+	  break;
+	}
+	
+#if MUTEX_INT==1
+	ReleaseMutex(&inIntr);
+#endif
+	_event = 0;
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+// Interrupt_0 Handler.
+// Both interrupts DIO0 and DIO1 are mapped on GPIO15. Se we have to look at 
+// the interrupt flags to see which interrupt(s) are called.
+//
+// NOTE:: This method may work not as good as just using more GPIO pins on 
+//  the ESP8266 mcu. But in practice it works good enough
+// ----------------------------------------------------------------------------
+void ICACHE_RAM_ATTR Interrupt_0()
+{
+	_event = 1;
+}
+
+
+// ----------------------------------------------------------------------------
+// Interrupt handler for DIO1 having High Value
+// As DIO0 and DIO1 may be multiplexed on one GPIO interrupt handler
+// (as we do) we have to be careful only to call the right Interrupt_x
+// handler and clear the corresponding interrupts for that dio.
+// NOTE: Make sure all Serial communication is only for debug level 3 and up.
+// Handler for:
+//		- CDDETD
+//		- RXTIMEOUT
+//		- (RXDONE error only)
+// ----------------------------------------------------------------------------
+void ICACHE_RAM_ATTR Interrupt_1()
+{
+	_event = 1;
+}
+
+// ----------------------------------------------------------------------------
+// Frequency Hopping Channel (FHSS) dio2
+// ----------------------------------------------------------------------------
+void ICACHE_RAM_ATTR Interrupt_2() 
+{
+	_event = 1;
+}
+
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_otaServer.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_otaServer.ino
@@ -1,0 +1,117 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains the ota code for the ESP Single Channel Gateway.
+
+// Provide OTA server funcionality so the 1ch gateway can be updated 
+// over the air.
+// This code uses the ESPhttpServer functions to update the gateway.
+
+#if A_OTA==1
+
+//extern ArduinoOTAClass ArduinoOTA;
+
+// Make sure that webserver is running before continuing
+
+// ----------------------------------------------------------------------------
+// setupOta
+// Function to run in the setup() function to initialise the update function
+// ----------------------------------------------------------------------------
+void setupOta(char *hostname) {
+
+	ArduinoOTA.begin();
+	Serial.println(F("setupOta:: Started"));
+	
+	// Hostname defaults to esp8266-[ChipID]
+	ArduinoOTA.setHostname(hostname);
+	
+	ArduinoOTA.onStart([]() {
+		String type;
+		// XXX version mispatch of platform.io and ArduinoOtaa
+		// see https://github.com/esp8266/Arduino/issues/3020
+		//if (ArduinoOTA.getCommand() == U_FLASH)
+			type = "sketch";
+		//else // U_SPIFFS
+		//	type = "filesystem";
+
+		// NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
+		Serial.println("Start updating " + type);
+	});
+	
+	ArduinoOTA.onEnd([]() {
+		Serial.println("\nEnd");
+	});
+	
+	ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+		Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+	});
+	
+	ArduinoOTA.onError([](ota_error_t error) {
+		Serial.printf("Error[%u]: ", error);
+		if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
+		else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
+		else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
+		else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
+		else if (error == OTA_END_ERROR) Serial.println("End Failed");
+	});
+	
+	
+	Serial.println("Ready");
+	Serial.print("IP address: ");
+	Serial.println(WiFi.localIP());
+	
+	// Only if the Webserver is active also
+#if A_SERVER==2										// Displaed for the moment
+	ESPhttpUpdate.rebootOnUpdate(false);
+   
+	server.on("/esp", HTTP_POST, [&](){
+   
+      HTTPUpdateResult ret = ESPhttpUpdate.update(server.arg("firmware"), "1.0.0");
+	  
+      switch(ret) {
+        case HTTP_UPDATE_FAILED:
+            //PREi::sendJSON(500, "Update failed.");
+			Serial.println(F("Update failed"));
+            break;
+        case HTTP_UPDATE_NO_UPDATES:
+            //PREi::sendJSON(304, "Update not necessary.");
+			Serial.println(F("Update not necessary"));
+            break;
+        case HTTP_UPDATE_OK:
+            //PREi::sendJSON(200, "Update started.");
+			Serial.println(F("Update started"));
+            ESP.restart();
+            break;
+		default:
+			Serial.println(F("setupOta:: Unknown ret="));
+      }
+	});
+#endif
+}
+
+
+// ----------------------------------------------------------------------------
+//
+//
+// ----------------------------------------------------------------------------
+void updateOtaa() {
+
+	String response="";
+	printIP((IPAddress)WiFi.localIP(),'.',response);
+	
+	ESPhttpUpdate.update(response, 80, "/arduino.bin");
+
+}
+
+
+#endif

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_repeater.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_repeater.ino
@@ -1,0 +1,46 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg
+// Verison 5.0.1
+// Date: 2017-11-15
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// NO WARRANTY OF ANY KIND IS PROVIDED
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains code for using the single channel gateway also as a sensor node. 
+// Please specify the DevAddr and the AppSKey below (and on your LoRa backend).
+// Also you will have to choose what sensors to forward to your application.
+//
+// ============================================================================
+		
+#if REPEATER==1
+
+#define _ICHAN 0
+#define _OCHAN 1
+
+#ifdef _TTNSERVER
+#error "Please undefined _THINGSERVER, for REAPETR shutdown WiFi"
+#endif
+
+// Send a LoRa message out from the gateway transmitter
+// XXX Maybe we should block the received ontul the message is transmitter
+
+int sendLora(char *msg, int len) {
+	// Check whete len is not exceeding maximum length
+	Serial.print("sendLora:: ");
+	
+	for (int i=0; i< len; i++) {
+		Serial.print(msg[1],HEX);
+		Serial.print('.');
+	}
+	
+	if (debug>=2) Serial.flush();
+	return(1);
+}
+
+#endif //REPEATER==1

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_sensor.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_sensor.ino
@@ -1,0 +1,504 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg
+// Verison 5.0.1
+// Date: 2017-11-15
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// NO WARRANTY OF ANY KIND IS PROVIDED
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains code for using the single channel gateway also as a sensor node. 
+// Please specify the DevAddr and the AppSKey below (and on your LoRa backend).
+// Also you will have to choose what sensors to forward to your application.
+//
+// ============================================================================
+		
+#if GATEWAYNODE==1
+
+unsigned char DevAddr[4]  = _DEVADDR ;				// see ESP-sc-gway.h
+
+
+// ----------------------------------------------------------------------------
+// XXX Experimental Read Internal Sensors
+//
+// You can monitor some settings of the RFM95/sx1276 chip. For example the temperature
+// which is set in REGTEMP in FSK mode (not in LORA). Or the battery value.
+// Find some sensible sensor values for LoRa radio and read them below in separate function
+//
+// ----------------------------------------------------------------------------
+//uint8_t readInternal(uint8_t reg) {
+//
+//	return 0;
+//}
+
+
+// ----------------------------------------------------------------------------
+// LoRaSensors() is a function that puts sensor values in the MACPayload and 
+// sends these values up to the server. For the server it is impossible to know 
+// whther or not the message comes from a LoRa node or from the gateway.
+//
+// The example code below adds a battery value in lCode (encoding protocol) but
+// of-course you can add any byte string you wish
+//
+// Parameters: 
+//	- buf: contains the buffer to put the sensor values in
+// Returns:
+//	- The amount of sensor characters put in the buffer 
+// ----------------------------------------------------------------------------
+static int LoRaSensors(uint8_t *buf) {
+
+	uint8_t internalSersors;
+	//internalSersors = readInternal(0x1A);
+	//if (internalSersors > 0) {		
+	//	return (internalSersors);
+	//}
+	
+	
+	buf[0] = 0x86;									// 134; User code <lCode + len==3 + Parity
+	buf[1] = 0x80;									// 128; lCode code <battery>
+	buf[2] = 0x3F;									//  63; lCode code <value>
+	// Parity = buf[0]==1 buf[1]=1 buf[2]=0 ==> even, so last bit of first byte must be 0
+	
+	return(3);	// return the number of bytes added to payload
+}
+
+
+// ----------------------------------------------------------------------------
+// XOR()
+// perform x-or function for buffer and key
+// Since we do this ONLY for keys and X, Y we know that we need to XOR 16 bytes.
+//
+// ----------------------------------------------------------------------------
+static void mXor(uint8_t *buf, uint8_t *key) {
+	for (uint8_t i = 0; i < 16; ++i) buf[i] ^= key[i];
+}
+
+
+// ----------------------------------------------------------------------------
+// SHIFT-LEFT
+// Shift the buffer buf left one bit
+// Parameters:
+//	- buf: An array of uint8_t bytes
+//	- len: Length of the array in bytes
+// ----------------------------------------------------------------------------
+static void shift_left(uint8_t * buf, uint8_t len) {
+    while (len--) {
+        uint8_t next = len ? buf[1] : 0;			// len 0 to 15
+
+        uint8_t val = (*buf << 1);
+        if (next & 0x80) val |= 0x01;
+        *buf++ = val;
+    }
+}
+
+
+// ----------------------------------------------------------------------------
+// generate_subkey
+// RFC 4493, para 2.3
+// ----------------------------------------------------------------------------
+static void generate_subkey(uint8_t *key, uint8_t *k1, uint8_t *k2) {
+
+	memset(k1, 0, 16);								// Fill subkey1 with 0x00
+	
+	// Step 1: Assume k1 is an all zero block
+	AES_Encrypt(k1,key);
+	
+	// Step 2: Analyse outcome of Encrypt operation (in k1), generate k1
+	if (k1[0] & 0x80) {
+		shift_left(k1,16);
+		k1[15] ^= 0x87;
+	}
+	else {
+		shift_left(k1,16);
+	}
+	
+	// Step 3: Generate k2
+	for (uint8_t i=0; i<16; i++) k2[i]=k1[i];
+	if (k1[0] & 0x80) {								// use k1(==k2) according rfc 
+		shift_left(k2,16);
+		k2[15] ^= 0x87;
+	}
+	else {
+		shift_left(k2,16);
+	}
+	
+	// step 4: Done, return k1 and k2
+	return;
+}
+
+
+// ----------------------------------------------------------------------------
+// ENCODEPACKET
+// In Sensor mode, we have to encode the user payload before sending.
+// The library files for AES are added to the library directory in AES.
+// For the moment we use the AES library made by ideetron as this library
+// is also used in the LMIC stack and is small in size.
+//
+// The function below follows the LoRa spec exactly.
+//
+// The resulting mumber of Bytes is returned by the functions. This means
+// 16 bytes per block, and as we add to the last block we also return 16
+// bytes for the last block.
+//
+// The LMIC code does not do this, so maybe we shorten the last block to only
+// the meaningful bytes in the last block. This means that encoded buffer
+// is exactly as big as the original message.
+//
+// NOTE:: Be aware that the LICENSE of the used AES library files 
+//	that we call with AES_Encrypt() is GPL3. It is used as-is,
+//  but not part of this code.
+//
+// cmac = aes128_encrypt(K, Block_A[i])
+// ----------------------------------------------------------------------------
+uint8_t encodePacket(uint8_t *Data, uint8_t DataLength, uint16_t FrameCount, uint8_t Direction) {
+
+	unsigned char AppSKey[16] = _APPSKEY ;	// see ESP-sc-gway.h
+	uint8_t i, j;
+	uint8_t Block_A[16];
+	uint8_t bLen=16;						// Block length is 16 except for last block in message
+		
+	uint8_t restLength = DataLength % 16;	// We work in blocks of 16 bytes, this is the rest
+	uint8_t numBlocks  = DataLength / 16;	// Number of whole blocks to encrypt
+	if (restLength>0) numBlocks++;			// And add block for the rest if any
+
+	for(i = 1; i <= numBlocks; i++) {
+		Block_A[0] = 0x01;
+		
+		Block_A[1] = 0x00; 
+		Block_A[2] = 0x00; 
+		Block_A[3] = 0x00; 
+		Block_A[4] = 0x00;
+
+		Block_A[5] = Direction;				// 0 is uplink
+
+		Block_A[6] = DevAddr[3];			// Only works for and with ABP
+		Block_A[7] = DevAddr[2];
+		Block_A[8] = DevAddr[1];
+		Block_A[9] = DevAddr[0];
+
+		Block_A[10] = (FrameCount & 0x00FF);
+		Block_A[11] = ((FrameCount >> 8) & 0x00FF);
+		Block_A[12] = 0x00; 				// Frame counter upper Bytes
+		Block_A[13] = 0x00;					// These are not used so are 0
+
+		Block_A[14] = 0x00;
+
+		Block_A[15] = i;
+
+		// Encrypt and calculate the S
+		AES_Encrypt(Block_A, AppSKey);
+		
+		// Last block? set bLen to rest
+		if ((i == numBlocks) && (restLength>0)) bLen = restLength;
+		
+		for(j = 0; j < bLen; j++) {
+			*Data = *Data ^ Block_A[j];
+			Data++;
+		}
+	}
+	//return(numBlocks*16);			// Do we really want to return all 16 bytes in lastblock
+	return(DataLength);				// or only 16*(numBlocks-1)+bLen;
+}
+
+
+// ----------------------------------------------------------------------------
+// MICPACKET()
+// Provide a valid MIC 4-byte code (par 2.4 of spec, RFC4493)
+// 		see also https://tools.ietf.org/html/rfc4493
+//
+// Although our own handler may choose not to interpret the last 4 (MIC) bytes
+// of a PHYSPAYLOAD physical payload message of in internal sensor,
+// The official TTN (and other) backends will intrpret the complete message and
+// conclude that the generated message is bogus.
+// So we sill really simulate internal messages coming from the -1ch gateway
+// to come from a real sensor and append 4 MIC bytes to every message that are 
+// perfectly legimate
+// Parameters:
+//	- data:			uint8_t array of bytes = ( MHDR | FHDR | FPort | FRMPayload )
+//	- len:			8=bit length of data, normally less than 64 bytes
+//	- FrameCount:	16-bit framecounter
+//	- dir:			0=up, 1=down
+//
+// B0 = ( 0x49 | 4 x 0x00 | Dir | 4 x DevAddr | 4 x FCnt |  0x00 | len )
+// MIC is cmac [0:3] of ( aes128_cmac(NwkSKey, B0 | Data )
+//
+// ----------------------------------------------------------------------------
+uint8_t micPacket(uint8_t *data, uint8_t len, uint16_t FrameCount, uint8_t dir) {
+
+
+	unsigned char NwkSKey[16] = _NWKSKEY ;
+	uint8_t Block_B[16];
+	uint8_t X[16];
+	uint8_t Y[16];
+	
+	// ------------------------------------
+	// build the B block used by the MIC process
+	Block_B[0]= 0x49;						// 1 byte MIC code
+			
+	Block_B[1]= 0x00;						// 4 byte 0x00
+	Block_B[2]= 0x00;
+	Block_B[3]= 0x00;
+	Block_B[4]= 0x00;
+	
+	Block_B[5]= dir;						// 1 byte Direction
+	
+	Block_B[6]= DevAddr[3];					// 4 byte DevAddr
+	Block_B[7]= DevAddr[2];
+	Block_B[8]= DevAddr[1];
+	Block_B[9]= DevAddr[0];
+	
+	Block_B[10]= (FrameCount & 0x00FF);		// 4 byte FCNT
+	Block_B[11]= ((FrameCount >> 8) & 0x00FF);
+	Block_B[12]= 0x00; 						// Frame counter upper Bytes
+	Block_B[13]= 0x00;						// These are not used so are 0
+	
+	Block_B[14]= 0x00;						// 1 byte 0x00
+	
+	Block_B[15]= len;						// 1 byte len
+	
+	// ------------------------------------
+	// Step 1: Generate the subkeys
+	//
+	uint8_t k1[16];
+	uint8_t k2[16];
+	generate_subkey(NwkSKey, k1, k2);
+	
+	// ------------------------------------
+	// Copy the data to a new buffer which is prepended with Block B0
+	//
+	uint8_t micBuf[len+16];					// B0 | data
+	for (uint8_t i=0; i<16; i++) micBuf[i]=Block_B[i];
+	for (uint8_t i=0; i<len; i++) micBuf[i+16]=data[i];
+	
+	// ------------------------------------
+	// Step 2: Calculate the number of blocks for CMAC
+	//
+	uint8_t numBlocks = len/16 + 1;			// Compensate for B0 block
+	if ((len % 16)!=0) numBlocks++;			// If we have only a part block, take it all
+	
+	// ------------------------------------
+	// Step 3: Calculate padding is necessary
+	//
+	uint8_t restBits = len%16;				// if numBlocks is not a multiple of 16 bytes
+	
+	
+	// ------------------------------------
+	// Step 5: Make a buffer of zeros
+	//
+	memset(X, 0, 16);
+	
+	// ------------------------------------
+	// Step 6: Do the actual encoding according to RFC
+	//
+	for(uint8_t i= 0x0; i < (numBlocks - 1); i++) {
+		for (uint8_t j=0; j<16; j++) Y[j] = micBuf[(i*16)+j];
+		mXor(Y, X);
+		AES_Encrypt(Y, NwkSKey);
+		for (uint8_t j=0; j<16; j++) X[j] = Y[j];
+	}
+	
+
+	// ------------------------------------
+	// Step 4: If there is a rest Block, padd it
+	// Last block. We move step4 to the end as we need Y
+	// to compute the last block
+	// 
+	if (restBits) {
+		for (uint8_t i=0; i<16; i++) {
+			if (i< restBits) Y[i] = micBuf[((numBlocks-1)*16)+i];
+			if (i==restBits) Y[i] = 0x80;
+			if (i> restBits) Y[i] = 0x00;
+		}
+		mXor(Y, k2);
+	}
+	else {
+		for (uint8_t i=0; i<16; i++) {
+			Y[i] = micBuf[((numBlocks-1)*16)+i];
+		}
+		mXor(Y, k1);
+	}
+	mXor(Y, X);
+	AES_Encrypt(Y,NwkSKey);
+	
+	// ------------------------------------
+	// Step 7: done, return the MIC size. 
+	// Only 4 bytes are returned (32 bits), which is less than the RFC recommends.
+	// We return by appending 4 bytes to data, so there must be space in data array.
+	//
+	data[len+0]=Y[0];
+	data[len+1]=Y[1];
+	data[len+2]=Y[2];
+	data[len+3]=Y[3];
+	return 4;
+}
+
+
+#if _CHECK_MIC==1
+// ----------------------------------------------------------------------------
+// CHECKMIC
+// Function to check the MIC computed for existing messages and for new messages
+// Parameters:
+//	- buf: LoRa buffer to check in bytes, last 4 bytes contain the MIC
+//	- len: Length of buffer in bytes
+//	- key: Key to use for MIC. Normally this is the NwkSKey
+//
+// ----------------------------------------------------------------------------
+static void checkMic(uint8_t *buf, uint8_t len, uint8_t *key) {
+	uint8_t cBuf[len+1];
+	
+	if (debug>=2) {
+		Serial.print(F("old="));
+		for (uint8_t i=0; i<len; i++) { 
+			printHexDigit(buf[i]); 
+			Serial.print(' '); 
+		}
+		Serial.println();
+	}	
+	for (uint8_t i=0; i<len-4; i++) cBuf[i] = buf[i];
+	len -=4;
+	
+	uint16_t FrameCount = ( cBuf[7] * 256 ) + cBuf[6];
+	len += micPacket(cBuf, len, FrameCount, 0);
+	
+	if (debug>=2) {
+		Serial.print(F("new="));
+		for (uint8_t i=0; i<len; i++) { 
+			printHexDigit(cBuf[i]); 
+			Serial.print(' '); 
+		}
+		Serial.println();
+	}
+}
+#endif
+
+// ----------------------------------------------------------------------------
+// SENSORPACKET
+// The gateway may also have local sensors that need reporting.
+// We will generate a message in gateway-UDP format for upStream messaging
+// so that for the backend server it seems like a LoRa node has reported a
+// sensor value.
+//
+// NOTE: We do not need ANY LoRa functions here since we are on the gateway.
+// We only need to send a gateway message upstream that looks like a node message.
+//
+// NOTE:: This function does encrypt the sensorpayload, and the backend
+//		picks it up fine as decoder thinks it is a MAC message.
+//
+// Par 4.0 LoraWan spec:
+//	PHYPayload =	( MHDR | MACPAYLOAD | MIC ) 
+// which is equal to
+//					( MHDR | ( FHDR | FPORT | FRMPAYLOAD ) | MIC )
+//
+//	This function makes the totalpackage and calculates MIC
+// Te maximum size of the message is: 12 + ( 9 + 2 + 64 ) + 4	
+// So message size should be lass than 128 bytes if Payload is limited to 64 bytes.
+//
+// return value:
+//	- On success returns the number of bytes to send
+//	- On error returns -1
+// ----------------------------------------------------------------------------
+int sensorPacket() {
+
+	uint8_t buff_up[512];								// Declare buffer here to avoid exceptions
+	uint8_t message[64]={ 0 };							// Payload, init to 0
+	uint8_t mlength = 0;
+	uint32_t tmst = micros();
+	
+	// In the next few bytes the fake LoRa message must be put
+	// PHYPayload = MHDR | MACPAYLOAD | MIC
+	// MHDR, 1 byte
+	// MIC, 4 bytes
+	
+	// ------------------------------
+	// MHDR (Para 4.2), bit 5-7 MType, bit 2-4 RFU, bit 0-1 Major
+	message[0] = 0x40;									// MHDR 0x40 == unconfirmed up message,
+														// FRU and major are 0
+	
+	// -------------------------------
+	// FHDR consists of 4 bytes addr, 1 byte Fctrl, 2 byte FCnt, 0-15 byte FOpts
+	// We support ABP addresses only for Gateways
+	message[1] = DevAddr[3];							// Last byte[3] of address
+	message[2] = DevAddr[2];
+	message[3] = DevAddr[1];
+	message[4] = DevAddr[0];							// First byte[0] of Dev_Addr
+	
+	message[5] = 0x00;									// FCtrl is normally 0
+	message[6] = frameCount % 0x100;					// LSB
+	message[7] = frameCount / 0x100;					// MSB
+
+	// -------------------------------
+	// FPort, either 0 or 1 bytes. Must be != 0 for non MAC messages such as user payload
+	//
+	message[8] = 0x01;									// FPort must not be 0
+	mlength = 9;
+	
+	// FRMPayload; Payload will be AES128 encoded using AppSKey
+	// See LoRa spec para 4.3.2
+	// You can add any byte string below based on you personal choice of sensors etc.
+	//
+	// Payload bytes in this example are encoded in the LoRaCode(c) format
+	uint8_t PayLength = LoRaSensors((uint8_t *)(message+mlength));
+	
+	// we have to include the AES functions at this stage in order to generate LoRa Payload.
+	uint8_t CodeLength = encodePacket((uint8_t *)(message+mlength), PayLength, (uint16_t)frameCount, 0);
+
+	mlength += CodeLength;								// length inclusive sensor data
+	
+	// MIC, Message Integrity Code
+	// As MIC is used by TTN (and others) we have to make sure that
+	// framecount is valid and the message is correctly encrypted.
+	// Note: Until MIC is done correctly, TTN does not receive these messages
+	//		 The last 4 bytes are MIC bytes.
+	//
+	mlength += micPacket((uint8_t *)(message), mlength, (uint16_t)frameCount, 0);
+
+	// So now our package is ready, and we can send it up through the gateway interface
+	// Note Be aware that the sensor message (which is bytes) in message will be
+	// be expanded if the server expacts JSON messages.
+	//
+	int buff_index = buildPacket(tmst, buff_up, message, mlength, true);
+	
+	frameCount++;
+	
+	// In order to save the memory, we only write the framecounter
+	// to EEPROM every 10 values. It also means that we will invalidate
+	// 10 value when restarting the gateway.
+	//
+	if (( frameCount % 10)==0) writeGwayCfg(CONFIGFILE);
+	
+	//yield();								// XXX Can we remove this here?
+	
+	if (buff_index > 512) {
+		if (debug>0) Serial.println(F("sensorPacket:: ERROR buffer size too large"));
+		return(-1);
+	}
+	
+	if (!sendUdp(ttnServer, _TTNPORT, buff_up, buff_index)) {
+		return(-1);
+	}
+#ifdef _THINGSERVER
+	if (!sendUdp(thingServer, _THINGPORT, buff_up, buff_index)) {
+		return(-1);
+	}
+#endif
+
+	if (_cad) {
+		// Set the state to CAD scanning after receiving
+		_state = S_SCAN;						// Inititialise scanner
+		cadScanner();
+	}
+	else {
+		// Reset all RX lora stuff
+		_state = S_RX;
+		rxLoraModem();	
+	}
+		
+	return(buff_index);
+}
+
+#endif //GATEWAYNODE==1

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_txRx.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_txRx.ino
@@ -1,0 +1,530 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+//	and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains the LoRa modem specific code enabling to receive
+// and transmit packages/messages.
+// ========================================================================================
+
+
+
+// ----------------------------------------------------------------------------
+// DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN DOWN 
+// Send DOWN a LoRa packet over the air to the node. This function does all the 
+// decoding of the server message and prepares a Payload buffer.
+// The payload is actually transmitted by the sendPkt() function.
+// This function is used for regular downstream messages and for JOIN_ACCEPT
+// messages.
+// NOTE: This is not an interrupt function, but is started by loop().
+// ----------------------------------------------------------------------------
+int sendPacket(uint8_t *buf, uint8_t length) 
+{
+	// Received package with Meta Data:
+	// codr	: "4/5"
+	// data	: "Kuc5CSwJ7/a5JgPHrP29X9K6kf/Vs5kU6g=="	// for example
+	// freq	: 868.1 									// 868100000
+	// ipol	: true/false
+	// modu : "LORA"
+	// powe	: 14										// Set by default
+	// rfch : 0											// Set by default
+	// size	: 21
+	// tmst : 1800642 									// for example
+	// datr	: "SF7BW125"
+	
+	// 12-byte header;
+	//		HDR (1 byte)
+	//		
+	//
+	// Data Reply for JOIN_ACCEPT as sent by server:
+	//		AppNonce (3 byte)
+	//		NetID (3 byte)
+	//		DevAddr (4 byte) [ 31..25]:NwkID , [24..0]:NwkAddr
+ 	//		DLSettings (1 byte)
+	//		RxDelay (1 byte)
+	//		CFList (fill to 16 bytes)
+			
+	int i=0;
+	StaticJsonBuffer<312> jsonBuffer;
+	char * bufPtr = (char *) (buf);
+	buf[length] = 0;
+	
+#if DUSB>=1
+	if (debug>=2) {
+		Serial.println((char *)buf);
+		Serial.print(F("<"));
+		Serial.flush();
+	}
+#endif
+	// Use JSON to decode the string after the first 4 bytes.
+	// The data for the node is in the "data" field. This function destroys original buffer
+	JsonObject& root = jsonBuffer.parseObject(bufPtr);
+		
+	if (!root.success()) {
+#if DUSB>=1
+		Serial.print (F("sendPacket:: ERROR Json Decode"));
+		if (debug>=2) {
+			Serial.print(':');
+			Serial.println(bufPtr);
+		}
+		Serial.flush();
+#endif
+		return(-1);
+	}
+	delay(1);
+	// Meta Data sent by server (example)
+	// {"txpk":{"codr":"4/5","data":"YCkEAgIABQABGmIwYX/kSn4Y","freq":868.1,"ipol":true,"modu":"LORA","powe":14,"rfch":0,"size":18,"tmst":1890991792,"datr":"SF7BW125"}}
+
+	// Used in the protocol:
+	const char * data	= root["txpk"]["data"];
+	uint8_t psize		= root["txpk"]["size"];
+	bool ipol			= root["txpk"]["ipol"];
+	uint8_t powe		= root["txpk"]["powe"];
+	uint32_t tmst		= (uint32_t) root["txpk"]["tmst"].as<unsigned long>();
+
+	// Not used in the protocol:
+	const char * datr	= root["txpk"]["datr"];			// eg "SF7BW125"
+	const float ff		= root["txpk"]["freq"];			// eg 869.525
+	const char * modu	= root["txpk"]["modu"];			// =="LORA"
+	const char * codr	= root["txpk"]["codr"];
+	//if (root["txpk"].containsKey("imme") ) {
+	//	const bool imme = root["txpk"]["imme"];			// Immediate Transmit (tmst don't care)
+	//}
+
+	if (data != NULL) {
+#if DUSB>=1
+		if (debug>=2) { 
+			Serial.print(F("data: ")); 
+			Serial.println((char *) data);
+			if (debug>=2) Serial.flush();
+		}
+#endif
+	}
+	else {
+#if DUSB>=1
+		Serial.println(F("sendPacket:: ERROR: data is NULL"));
+		if (debug>=2) Serial.flush();
+#endif
+		return(-1);
+	}
+	
+	uint8_t iiq = (ipol? 0x40: 0x27);					// if ipol==true 0x40 else 0x27
+	uint8_t crc = 0x00;									// switch CRC off for TX
+	uint8_t payLength = base64_dec_len((char *) data, strlen(data));
+	
+	// Fill payload with decoded message
+	base64_decode((char *) payLoad, (char *) data, strlen(data));
+
+	// Compute wait time in microseconds
+	uint32_t w = (uint32_t) (tmst - micros());
+	
+#if _STRICT_1CH == 1
+	// Use RX1 timeslot as this is our frequency.
+	// Do not use RX2 or JOIN2 as they contain other frequencies
+	if ((w>1000000) && (w<3000000)) { tmst-=1000000; }
+	else if ((w>6000000) && (w<7000000)) { tmst-=1000000; }
+	
+	const uint8_t sfTx = sfi;							// Take care, TX sf not to be mixed with SCAN
+	const uint32_t fff = freq;
+#else
+	const uint8_t sfTx = atoi(datr+2);					// Convert "SF9BW125" to 9
+	// convert double frequency (MHz) into uint32_t frequency in Hz.
+	const uint32_t fff = (uint32_t) ((uint32_t)((ff+0.000035)*1000)) * 1000;
+#endif
+
+	// All data is in Payload and parameters and need to be transmitted.
+	// The function is called in user-space
+	_state = S_TX;										// _state set to transmit
+	
+	LoraDown.payLoad = payLoad;
+	LoraDown.payLength = payLength;
+	LoraDown.tmst = tmst;
+	LoraDown.sfTx = sfTx;
+	LoraDown.powe = powe;
+	LoraDown.fff = fff;
+	LoraDown.crc = crc;
+	LoraDown.iiq = iiq;
+
+	Serial.println(F("sendPacket:: LoraDown filled"));
+
+#if DUSB>=1
+	if (debug>=2) {
+		Serial.print(F("Request:: "));
+		Serial.print(F(" tmst=")); Serial.print(tmst); Serial.print(F(" wait=")); Serial.println(w);
+		
+		Serial.print(F(" strict=")); Serial.print(_STRICT_1CH);
+		Serial.print(F(" datr=")); Serial.println(datr);
+		Serial.print(F(" freq=")); Serial.print(freq); Serial.print(F(" ->")); Serial.println(fff);
+		Serial.print(F(" sf  =")); Serial.print(sf); Serial.print(F(" ->")); Serial.print(sfTx);
+		
+		Serial.print(F(" modu=")); Serial.print(modu);
+		Serial.print(F(" powe=")); Serial.print(powe);
+		Serial.print(F(" codr=")); Serial.println(codr);
+
+		Serial.print(F(" ipol=")); Serial.println(ipol);
+		Serial.println();								// empty line between messages
+	}
+#endif
+
+	if (payLength != psize) {
+#if DUSB>=1
+		Serial.print(F("sendPacket:: WARNING payLength: "));
+		Serial.print(payLength);
+		Serial.print(F(", psize="));
+		Serial.println(psize);
+		if (debug>=2) Serial.flush();
+#endif
+	}
+#if DUSB>=1
+	else if (debug >= 2) {
+		for (i=0; i<payLength; i++) {
+			Serial.print(payLoad[i],HEX); 
+			Serial.print(':'); 
+		}
+		Serial.println();
+		if (debug>=2) Serial.flush();
+	}
+#endif
+	cp_up_pkt_fwd++;
+
+#if DUSB>=1
+	Serial.println(F("sendPacket:: fini OK"));
+#endif
+	return 1;
+}//sendPacket
+
+
+
+
+// ----------------------------------------------------------------------------
+// UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP
+// Based on the information read from the LoRa transceiver (or fake message)
+// build a gateway message to send upstream.
+//
+// parameters:
+// tmst: Timestamp to include in the upstream message
+// buff_up: The buffer that is generated for upstream
+// message: The payload message to include in the the buff_up
+// messageLength: The number of bytes received by the LoRa transceiver
+// internal: Boolean value to indicate whether the local sensor is processed
+//
+// ----------------------------------------------------------------------------
+int buildPacket(uint32_t tmst, uint8_t *buff_up, struct LoraUp LoraUp, bool internal) 
+{
+	long SNR;
+    int rssicorr;
+	int prssi;											// packet rssi
+	
+	char cfreq[12] = {0};								// Character array to hold freq in MHz
+	lastTmst = tmst;									// Following/according to spec
+	int buff_index=0;
+	char b64[256];
+	
+	uint8_t *message = LoraUp.payLoad;
+	char messageLength = LoraUp.payLength;
+		
+#if _CHECK_MIC==1
+	unsigned char NwkSKey[16] = _NWKSKEY;
+	checkMic(message, messageLength, NwkSKey);
+#endif
+
+	// Read SNR and RSSI from the register. Note: Not for internal sensors!
+	// For internal sensor we fake these values as we cannot read a register
+	if (internal) {
+		SNR = 12;
+		prssi = 50;
+		rssicorr = 157;
+	}
+	else {
+		SNR = LoraUp.snr;
+		prssi = LoraUp.prssi;								// read register 0x1A, packet rssi
+		rssicorr = LoraUp.rssicorr;
+	}
+
+#if STATISTICS >= 1
+	// Receive statistics
+	for (int m=( MAX_STAT -1); m>0; m--) statr[m]=statr[m-1];
+	statr[0].tmst = millis();
+	statr[0].ch= ifreq;
+	statr[0].prssi = prssi - rssicorr;
+#if RSSI==1
+	statr[0].rssi = _rssi - rssicorr;
+#endif
+	statr[0].sf = LoraUp.sf;
+	statr[0].node = ( message[1]<<24 | message[2]<<16 | message[3]<<8 | message[4] );
+
+#if STATISTICS >= 2
+	switch (statr[0].sf) {
+		case SF7: statc.sf7++; break;
+		case SF8: statc.sf8++; break;
+		case SF9: statc.sf9++; break;
+		case SF10: statc.sf10++; break;
+		case SF11: statc.sf11++; break;
+		case SF12: statc.sf12++; break;
+	}
+#endif	
+#endif
+
+#if DUSB>=1	
+	if (debug>=1) {
+		Serial.print(F("pRSSI: "));
+		Serial.print(prssi-rssicorr);
+		Serial.print(F(" RSSI: "));
+		Serial.print(_rssi - rssicorr);
+		Serial.print(F(" SNR: "));
+		Serial.print(SNR);
+		Serial.print(F(" Length: "));
+		Serial.print((int)messageLength);
+		Serial.print(F(" -> "));
+		int i;
+		for (i=0; i< messageLength; i++) {
+					Serial.print(message[i],HEX);
+					Serial.print(' ');
+		}
+		Serial.println();
+		yield();
+	}
+#endif
+
+// Show received message status on OLED display
+#if OLED==1
+      display.clear();
+      display.setFont(ArialMT_Plain_16);
+      display.setTextAlignment(TEXT_ALIGN_LEFT);
+      char timBuff[20];
+      sprintf(timBuff, "%02i:%02i:%02i", hour(), minute(), second());
+      display.drawString(0, 0, "Time: " );
+      display.drawString(40, 0, timBuff);
+      display.drawString(0, 16, "RSSI: " );
+      display.drawString(40, 16, String(prssi-rssicorr));
+      display.drawString(70, 16, ",SNR: " );
+      display.drawString(110, 16, String(SNR) );
+	  
+	  display.drawString(0, 32, "Addr: " );
+	  
+      if (message[4] < 0x10) display.drawString( 40, 32, "0"+String(message[4], HEX)); else display.drawString( 40, 32, String(message[4], HEX));
+	  if (message[3] < 0x10) display.drawString( 61, 32, "0"+String(message[3], HEX)); else display.drawString( 61, 32, String(message[3], HEX));
+	  if (message[2] < 0x10) display.drawString( 82, 32, "0"+String(message[2], HEX)); else display.drawString( 82, 32, String(message[2], HEX));
+	  if (message[1] < 0x10) display.drawString(103, 32, "0"+String(message[1], HEX)); else display.drawString(103, 32, String(message[1], HEX));
+	  
+      display.drawString(0, 48, "LEN: " );
+      display.drawString(40, 48, String((int)messageLength) );
+      display.display();
+	  yield();
+#endif
+			
+	int j;
+	
+	// XXX Base64 library is nopad. So we may have to add padding characters until
+	// 	message Length is multiple of 4!
+	// Encode message with messageLength into b64
+	int encodedLen = base64_enc_len(messageLength);		// max 341
+#if DUSB>=1
+	if ((debug>=1) && (encodedLen>255)) {
+		Serial.println(F("buildPacket:: b64 error"));
+		if (debug>=2) Serial.flush();
+	}
+#endif
+	base64_encode(b64, (char *) message, messageLength);// max 341
+
+	// pre-fill the data buffer with fixed fields
+	buff_up[0] = PROTOCOL_VERSION;						// 0x01 still
+	buff_up[3] = PKT_PUSH_DATA;							// 0x00
+
+	// READ MAC ADDRESS OF ESP8266, and insert 0xFF 0xFF in the middle
+	buff_up[4]  = MAC_array[0];
+	buff_up[5]  = MAC_array[1];
+	buff_up[6]  = MAC_array[2];
+	buff_up[7]  = 0xFF;
+	buff_up[8]  = 0xFF;
+	buff_up[9]  = MAC_array[3];
+	buff_up[10] = MAC_array[4];
+	buff_up[11] = MAC_array[5];
+
+	// start composing datagram with the header 
+	uint8_t token_h = (uint8_t)rand(); 					// random token
+	uint8_t token_l = (uint8_t)rand(); 					// random token
+	buff_up[1] = token_h;
+	buff_up[2] = token_l;
+	buff_index = 12; 									// 12-byte binary (!) header
+
+	// start of JSON structure that will make payload
+	memcpy((void *)(buff_up + buff_index), (void *)"{\"rxpk\":[", 9);
+	buff_index += 9;
+	buff_up[buff_index] = '{';
+	++buff_index;
+	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, "\"tmst\":%u", tmst);
+#if DUSB>=1
+		if ((j<0) && (debug>=1)) {
+			Serial.println(F("buildPacket:: Error "));
+		}
+#endif
+	buff_index += j;
+	ftoa((double)freq/1000000,cfreq,6);					// XXX This can be done better
+	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, ",\"chan\":%1u,\"rfch\":%1u,\"freq\":%s", 0, 0, cfreq);
+	buff_index += j;
+	memcpy((void *)(buff_up + buff_index), (void *)",\"stat\":1", 9);
+	buff_index += 9;
+	memcpy((void *)(buff_up + buff_index), (void *)",\"modu\":\"LORA\"", 14);
+	buff_index += 14;
+	
+	/* Lora datarate & bandwidth, 16-19 useful chars */
+	switch (LoraUp.sf) {
+		case SF6:
+			memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF6", 12);
+			buff_index += 12;
+			break;
+		case SF7:
+			memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF7", 12);
+			buff_index += 12;
+			break;
+		case SF8:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF8", 12);
+            buff_index += 12;
+            break;
+		case SF9:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF9", 12);
+            buff_index += 12;
+            break;
+		case SF10:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF10", 13);
+            buff_index += 13;
+            break;
+		case SF11:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF11", 13);
+            buff_index += 13;
+            break;
+		case SF12:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF12", 13);
+            buff_index += 13;
+            break;
+		default:
+            memcpy((void *)(buff_up + buff_index), (void *)",\"datr\":\"SF?", 12);
+            buff_index += 12;
+	}
+	memcpy((void *)(buff_up + buff_index), (void *)"BW125\"", 6);
+	buff_index += 6;
+	memcpy((void *)(buff_up + buff_index), (void *)",\"codr\":\"4/5\"", 13);
+	buff_index += 13;
+	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, ",\"lsnr\":%li", SNR);
+	buff_index += j;
+	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, ",\"rssi\":%d,\"size\":%u", prssi-rssicorr, messageLength);
+	buff_index += j;
+	memcpy((void *)(buff_up + buff_index), (void *)",\"data\":\"", 9);
+	buff_index += 9;
+
+	// Use gBase64 library to fill in the data string
+	encodedLen = base64_enc_len(messageLength);			// max 341
+	j = base64_encode((char *)(buff_up + buff_index), (char *) message, messageLength);
+
+	buff_index += j;
+	buff_up[buff_index] = '"';
+	++buff_index;
+
+	// End of packet serialization
+	buff_up[buff_index] = '}';
+	++buff_index;
+	buff_up[buff_index] = ']';
+	++buff_index;
+	
+	// end of JSON datagram payload */
+	buff_up[buff_index] = '}';
+	++buff_index;
+	buff_up[buff_index] = 0; 							// add string terminator, for safety
+#if DUSB>=1
+	if (debug>=2) {
+		Serial.print(F("RXPK:: "));
+		Serial.println((char *)(buff_up + 12));			// DEBUG: display JSON payload
+	}
+	if (debug>= 2) {
+		Serial.print(F("RXPK:: package length="));
+		Serial.println(buff_index);
+	}
+#endif
+	return(buff_index);
+}// buildPacket
+
+
+
+
+
+// ----------------------------------------------------------------------------
+// UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP UP 
+// Receive a LoRa package over the air, LoRa
+//
+// Receive a LoRa message and fill the buff_up char buffer.
+// returns values:
+// - returns the length of string returned in buff_up
+// - returns -1 when no message arrived.
+//
+// This is the "highlevel" function called by loop()
+// _state is S_RX when starting and
+// _state is S_STANDBY when leaving function
+// ----------------------------------------------------------------------------
+int receivePacket()
+{
+	uint8_t buff_up[TX_BUFF_SIZE]; 					// buffer to compose the upstream packet to backend server
+	long SNR;
+	uint8_t message[128] = { 0x00 };					// MSG size is 128 bytes for rx
+	uint8_t messageLength = 0;
+	
+	// Regular message received, see SX1276 spec table 18
+	// Next statement could also be a "while" to combine several messages received
+	// in one UDP message as the Semtech Gateway spec does allow this.
+	// XXX Not yet supported
+
+		// Take the timestamp as soon as possible, to have accurate reception timestamp
+		// TODO: tmst can jump if micros() overflow.
+		uint32_t tmst = (uint32_t) micros();			// Only microseconds, rollover in 
+		lastTmst = tmst;								// Following/according to spec
+		
+		// Handle the physical data read from LoraUp
+		if (LoraUp.payLength > 0) {
+
+			// externally received packet, so last parameter is false (==LoRa external)
+            int build_index = buildPacket(tmst, buff_up, LoraUp, false);
+
+			// REPEATER is a special function where we retransmit received 
+			// message on _ICHANN to _OCHANN.
+			// Note:: For the moment _OCHANN is not allowed to be same as _ICHANN
+#if REPEATER==1
+			if (!sendLora(LoraUp.payLoad, LoraUp.payLength)) {
+				return(-3);
+			}
+#endif
+
+			LoraUp.payLength = 0;
+			LoraUp.payLoad[0] = 0x00;
+			
+			// This is one of the potential problem areas.
+			// If possible, USB traffic should be left out of interrupt routines
+			// rxpk PUSH_DATA received from node is rxpk (*2, par. 3.2)
+#ifdef _TTNSERVER
+			if (!sendUdp(ttnServer, _TTNPORT, buff_up, build_index)) {
+				return(-1); 							// received a message
+			}
+			yield();
+#endif
+
+#ifdef _THINGSERVER
+			if (!sendUdp(thingServer, _THINGPORT, buff_up, build_index)) {
+				return(-2); 							// received a message
+			}
+#endif
+			return(build_index);
+        }
+		
+	return(0);											// failure no message read
+	
+}//receivePacket
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_wwwServer.ino
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/_wwwServer.ino
@@ -1,0 +1,1018 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// 	based on work done by many people and making use of several libraries.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains the webserver code for the ESP Single Channel Gateway.
+
+// Note:
+// The ESP Webserver works with Strings to display html content. 
+// Care must be taken that not all data is output to the webserver in one string
+// as this will use a LOT of memory and possibly kill the heap (cause system
+// crash or other unreliable behaviour.
+// Instead, output of the various tables on the webpage should be displayed in
+// chucks so that strings are limited in size.
+// Be aware that using no strings but only sendContent() calls has its own
+// disadvantage that these calls take a lot of time and cause the page to be
+// displayed like an old typewriter.
+// So, the trick is to make chucks that are sent to the website by using
+// a response String but not make those Strings too big.
+
+// ----------------------------------------------------------------------------
+// PRINT IP
+// Output the 4-byte IP address for easy printing.
+// As this function is also used by _otaServer.ino do not put in #define
+// ----------------------------------------------------------------------------
+static void printIP(IPAddress ipa, const char sep, String& response)
+{
+	response+=(IPAddress)ipa[0]; response+=sep;
+	response+=(IPAddress)ipa[1]; response+=sep;
+	response+=(IPAddress)ipa[2]; response+=sep;
+	response+=(IPAddress)ipa[3];
+}
+
+//
+// The remainder of the file ONLY works is A_SERVER=1 is set.
+//
+#if A_SERVER==1
+
+// ================================================================================
+// WEBSERVER DECLARATIONS 
+
+// None at the moment
+
+// ================================================================================
+// WEBSERVER FUNCTIONS 
+
+
+// ----------------------------------------------------------------------------
+// Print a HEXadecimal string from a 4-byte char string
+//
+// ----------------------------------------------------------------------------
+static void printHEX(char * hexa, const char sep, String& response) 
+{
+	char m;
+	m = hexa[0]; if (m<016) response+='0'; response += String(m, HEX);  response+=sep;
+	m = hexa[1]; if (m<016) response+='0'; response += String(m, HEX);  response+=sep;
+	m = hexa[2]; if (m<016) response+='0'; response += String(m, HEX);  response+=sep;
+	m = hexa[3]; if (m<016) response+='0'; response += String(m, HEX);  response+=sep;
+}
+
+// ----------------------------------------------------------------------------
+// stringTime
+// Only when RTC is present we print real time values
+// t contains number of milli seconds since system started that the event happened.
+// So a value of 100 would mean that the event took place 1 minute and 40 seconds ago
+// ----------------------------------------------------------------------------
+static void stringTime(unsigned long t, String& response) {
+
+	if (t==0) { response += "--"; return; }
+	
+	// now() gives seconds since 1970
+	time_t eventTime = now() - ((millis()-t)/1000);
+	byte _hour   = hour(eventTime);
+	byte _minute = minute(eventTime);
+	byte _second = second(eventTime);
+	
+	switch(weekday(eventTime)) {
+		case 1: response += "Sunday "; break;
+		case 2: response += "Monday "; break;
+		case 3: response += "Tuesday "; break;
+		case 4: response += "Wednesday "; break;
+		case 5: response += "Thursday "; break;
+		case 6: response += "Friday "; break;
+		case 7: response += "Saturday "; break;
+	}
+	response += String() + day(eventTime) + "-";
+	response += String() + month(eventTime) + "-";
+	response += String() + year(eventTime) + " ";
+	
+	if (_hour < 10) response += "0";
+	response += String() + _hour + ":";
+	if (_minute < 10) response += "0";
+	response += String() + _minute + ":";
+	if (_second < 10) response += "0";
+	response += String() + _second;
+}
+
+
+
+
+// ----------------------------------------------------------------------------
+// SET ESP8266 WEB SERVER VARIABLES
+//
+// This funtion implements the WiFI Webserver (very simple one). The purpose
+// of this server is to receive simple admin commands, and execute these
+// results are sent back to the web client.
+// Commands: DEBUG, ADDRESS, IP, CONFIG, GETTIME, SETTIME
+// The webpage is completely built response and then printed on screen.
+// ----------------------------------------------------------------------------
+static void setVariables(const char *cmd, const char *arg) {
+
+	// DEBUG settings; These can be used as a single argument
+	if (strcmp(cmd, "DEBUG")==0) {									// Set debug level 0-2
+		if (atoi(arg) == 1) {
+			debug = (debug+1)%4;
+		}	
+		else if (atoi(arg) == -1) {
+			debug = (debug+3)%4;
+		}
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+	
+	if (strcmp(cmd, "CAD")==0) {									// Set -cad on=1 or off=0
+		_cad=(bool)atoi(arg);
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+	
+	if (strcmp(cmd, "HOP")==0) {									// Set -hop on=1 or off=0
+		_hop=(bool)atoi(arg);
+		if (! _hop) { 
+			ifreq=0; 
+			freq=freqs[0]; 
+			rxLoraModem(); 
+		}
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+	
+	if (strcmp(cmd, "DELAY")==0) {									// Set delay usecs
+		txDelay+=atoi(arg)*1000;
+	}
+	
+	// SF; Handle Spreading Factor Settings
+	if (strcmp(cmd, "SF")==0) {
+		uint8_t sfi = sf;
+		if (atoi(arg) == 1) {
+			if (sf>=SF12) sf=SF7; else sf= (sf_t)((int)sf+1);
+		}	
+		else if (atoi(arg) == -1) {
+			if (sf<=SF7) sf=SF12; else sf= (sf_t)((int)sf-1);
+		}
+		rxLoraModem();												// Reset the radion with the new spreading factor
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+	
+	// FREQ; Handle Frequency  Settings
+	if (strcmp(cmd, "FREQ")==0) {
+		uint8_t nf = sizeof(freqs)/sizeof(int);						// Number of elements in array
+		
+		// Compute frequency index
+		if (atoi(arg) == 1) {
+			if (ifreq==(nf-1)) ifreq=0; else ifreq++;
+		}
+		else if (atoi(arg) == -1) {
+			Serial.println("down");
+			if (ifreq==0) ifreq=(nf-1); else ifreq--;
+		}
+
+		freq = freqs[ifreq];
+		rxLoraModem();												// Reset the radion with the new frequency
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+
+	//if (strcmp(cmd, "GETTIME")==0) { Serial.println(F("gettime tbd")); }	// Get the local time
+	
+	//if (strcmp(cmd, "SETTIME")==0) { Serial.println(F("settime tbd")); }	// Set the local time
+	
+	if (strcmp(cmd, "HELP")==0)    { Serial.println(F("Display Help Topics")); }
+	
+#if GATEWAYNODE==1
+	if (strcmp(cmd, "NODE")==0) {									// Set node on=1 or off=0
+		gwayConfig.isNode =(bool)atoi(arg);
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+	
+	if (strcmp(cmd, "FCNT")==0)   { 
+		frameCount=0; 
+		rxLoraModem();												// Reset the radion with the new frequency
+		writeGwayCfg(CONFIGFILE);
+	}
+#endif
+	
+#if WIFIMANAGER==1
+	if (strcmp(cmd, "NEWSSID")==0) { 
+		WiFiManager wifiManager;
+		strcpy(wpa[0].login,""); 
+		strcpy(wpa[0].passw,"");
+		WiFi.disconnect();
+		wifiManager.autoConnect(AP_NAME, AP_PASSWD );
+	}
+#endif
+
+#if A_OTA==1
+	if (strcmp(cmd, "UPDATE")==0) {
+		if (atoi(arg) == 1) {
+			updateOtaa();
+		}
+	}
+#endif
+
+#if A_REFRESH==1
+	if (strcmp(cmd, "REFR")==0) {									// Set refresh on=1 or off=0
+		gwayConfig.refresh =(bool)atoi(arg);
+		writeGwayCfg(CONFIGFILE);									// Save configuration to file
+	}
+#endif
+
+}
+
+
+// ----------------------------------------------------------------------------
+// OPEN WEB PAGE
+//	This is the init function for opening the webpage
+//
+// ----------------------------------------------------------------------------
+static void openWebPage()
+{
+	++gwayConfig.views;									// increment number of views
+#if A_REFRESH==1
+	//server.client().stop();							// Experimental, stop webserver in case something is still running!
+#endif
+	String response="";	
+
+	server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+	server.sendHeader("Pragma", "no-cache");
+	server.sendHeader("Expires", "-1");
+	
+	// init webserver, fill the webpage
+	// NOTE: The page is renewed every _WWW_INTERVAL seconds, please adjust in ESP-sc-gway.h
+	//
+	server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+	server.send(200, "text/html", "");
+#if A_REFRESH==1
+	if (gwayConfig.refresh) {
+		response += String() + "<!DOCTYPE HTML><HTML><HEAD><meta http-equiv='refresh' content='"+_WWW_INTERVAL+";http://";
+		printIP((IPAddress)WiFi.localIP(),'.',response);
+#ifdef ESP32BUILD
+    response += "'><TITLE>ESP32 1ch Gateway</TITLE>";
+#else    
+		response += "'><TITLE>ESP8266 1ch Gateway</TITLE>";
+#endif
+	}
+	else {
+		response += String() + "<!DOCTYPE HTML><HTML><HEAD><TITLE>ESP8266 1ch Gateway</TITLE>";
+	}
+#else
+	response += String() + "<!DOCTYPE HTML><HTML><HEAD><TITLE>ESP8266 1ch Gateway</TITLE>";
+#endif
+	response += "<META HTTP-EQUIV='CONTENT-TYPE' CONTENT='text/html; charset=UTF-8'>";
+	response += "<META NAME='AUTHOR' CONTENT='M. Westenberg (mw1554@hotmail.com)'>";
+
+	response += "<style>.thead {background-color:green; color:white;} ";
+	response += ".cell {border: 1px solid black;}";
+	response += ".config_table {max_width:100%; min-width:400px; width:95%; border:1px solid black; border-collapse:collapse;}";
+	response += "</style></HEAD><BODY>";
+	
+	response +="<h1>ESP Gateway Config</h1>";
+
+	response +="Version: "; response+=VERSION;
+	response +="<br>ESP alive since "; 					// STARTED ON
+	stringTime(1, response);
+
+	response +=", Uptime: ";							// UPTIME
+	uint32_t secs = millis()/1000;
+	uint16_t days = secs / 86400;						// Determine number of days
+	uint8_t _hour   = hour(secs);
+	uint8_t _minute = minute(secs);
+	uint8_t _second = second(secs);
+	response += String() + days + "-";
+	if (_hour < 10) response += "0";
+	response += String() + _hour + ":";
+	if (_minute < 10) response += "0";
+	response += String() + _minute + ":";
+	if (_second < 10) response += "0";
+	response += String() + _second;
+	
+	response +="<br>Current time    "; 					// CURRENT TIME
+	stringTime(millis(), response);
+	response +="<br>";
+	
+	server.sendContent(response);
+}
+
+
+// ----------------------------------------------------------------------------
+// CONFIG DATA
+//
+//
+// ----------------------------------------------------------------------------
+static void configData() 
+{
+	String response="";
+	String bg="";
+	
+	response +="<h2>Gateway Settings</h2>";
+	
+	response +="<table class=\"config_table\">";
+	response +="<tr>";
+	response +="<th class=\"thead\">Setting</th>";
+	response +="<th style=\"background-color: green; color: white; width:120px;\">Value</th>";
+	response +="<th colspan=\"2\" style=\"background-color: green; color: white; width:100px;\">Set</th>";
+	response +="</tr>";
+	
+	bg = " background-color: ";
+	bg += ( _cad ? "LightGreen" : "orange" );
+	response +="<tr><td class=\"cell\">CAD</td>";
+	response +="<td style=\"border: 1px solid black;"; response += bg; response += "\">";
+	response += ( _cad ? "ON" : "OFF" );
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"CAD=1\"><button>ON</button></a></td>";
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"CAD=0\"><button>OFF</button></a></td>";
+	response +="</tr>";
+	
+	bg = " background-color: ";
+	bg += ( _hop ? "LightGreen" : "orange" );
+	response +="<tr><td class=\"cell\">HOP</td>";
+	response +="<td style=\"border: 1px solid black;"; response += bg; response += "\">";
+	response += ( _hop ? "ON" : "OFF" );
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"HOP=1\"><button>ON</button></a></td>";
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"HOP=0\"><button>OFF</button></a></td>";
+	response +="</tr>";
+	
+	response +="<tr><td class=\"cell\">SF Setting</td><td class=\"cell\">";
+	if (_cad) {
+		response += "AUTO</td>";
+	}
+	else {
+		response += sf;
+		response +="<td class=\"cell\"><a href=\"SF=-1\"><button>-</button></a></td>";
+		response +="<td class=\"cell\"><a href=\"SF=1\"><button>+</button></a></td>";
+	}
+	response +="</tr>";
+	
+	// Channel
+	response +="<tr><td class=\"cell\">Channel</td>";
+	response +="<td class=\"cell\">"; 
+	if (_hop) {
+		response += "AUTO</td>";
+	}
+	else {
+		response += String() + ifreq; 
+		response +="</td>";
+		response +="<td class=\"cell\"><a href=\"FREQ=-1\"><button>-</button></a></td>";
+		response +="<td class=\"cell\"><a href=\"FREQ=1\"><button>+</button></a></td>";
+	}
+	response +="</tr>";
+
+	// Debugging options	
+	response +="<tr><td class=\"cell\">";
+	response +="Debug level</td><td class=\"cell\">"; 
+	response +=debug; 
+	response +="</td>";
+	response +="<td class=\"cell\"><a href=\"DEBUG=-1\"><button>-</button></a></td>";
+	response +="<td class=\"cell\"><a href=\"DEBUG=1\"><button>+</button></a></td>";
+	response +="</tr>";
+
+	// Serial Debugging
+	response +="<tr><td class=\"cell\">";
+	response +="Usb Debug</td><td class=\"cell\">"; 
+	response +=DUSB; 
+	response +="</td>";
+	//response +="<td class=\"cell\"> </td>";
+	//response +="<td class=\"cell\"> </td>";
+	response +="</tr>";
+	
+#if GATEWAYNODE==1
+	response +="<tr><td class=\"cell\">Framecounter Internal Sensor</td>";
+	response +="<td class=\"cell\">";
+	response +=frameCount;
+	response +="</td><td colspan=\"2\" style=\"border: 1px solid black;\">";
+	response +="<button><a href=\"/FCNT\">RESET</a></button></td>";
+	response +="</tr>";
+	
+	bg = " background-color: ";
+	bg += ( (gwayConfig.isNode == 1) ? "LightGreen" : "orange" );
+	response +="<tr><td class=\"cell\">Gateway Node</td>";
+	response +="<td class=\"cell\" style=\"border: 1px solid black;" + bg + "\">";
+	response += ( (gwayConfig.isNode == true) ? "ON" : "OFF" );
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"NODE=1\"><button>ON</button></a></td>";
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"NODE=0\"><button>OFF</button></a></td>";
+	response +="</tr>";
+#endif
+
+#if A_REFRESH==1
+	bg = " background-color: ";
+	bg += ( (gwayConfig.refresh == 1) ? "LightGreen" : "orange" );
+	response +="<tr><td class=\"cell\">WWW Refresh</td>";
+	response +="<td class=\"cell\" style=\"border: 1px solid black;" + bg + "\">";
+	response += ( (gwayConfig.refresh == 1) ? "ON" : "OFF" );
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"REFR=1\"><button>ON</button></a></td>";
+	response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"REFR=0\"><button>OFF</button></a></td>";
+	response +="</tr>";
+#endif
+
+#if WIFIMANAGER==1
+	response +="<tr><td>";
+	response +="Click <a href=\"/NEWSSID\">here</a> to reset accesspoint<br>";
+	response +="</td><td></td></tr>";
+#endif
+
+	// Reset all statistics
+#if STATISTICS >= 1
+	response +="<tr><td class=\"cell\">Statistics</td>";
+	response +=String() + "<td class=\"cell\">"+statc.resets+"</td>";
+	response +="<td colspan=\"2\" class=\"cell\"><a href=\"/RESET\"><button>RESET</button></a></td></tr>";
+	
+	response +="<tr><td class=\"cell\">Boots and Resets</td>";
+	response +=String() + "<td class=\"cell\">"+gwayConfig.boots+"</td>";
+	response +="<td colspan=\"2\" class=\"cell\"><a href=\"/BOOT\"><button>RESET</button></a></td></tr>";
+#endif
+	response +="</table>";
+	
+	// Update Firmware all statistics
+	response +="<tr><td class=\"cell\">Update Firmware</td>";
+	response +="<td class=\"cell\"></td><td colspan=\"2\" class=\"cell\"><a href=\"/UPDATE=1\"><button>RESET</button></a></td></tr>";
+	response +="</table>";
+	
+	server.sendContent(response);
+}
+
+
+// ----------------------------------------------------------------------------
+// INTERRUPT DATA
+// Display interrupt data, but only for debug >= 2
+//
+// ----------------------------------------------------------------------------
+static void interruptData()
+{
+	uint8_t flags = readRegister(REG_IRQ_FLAGS);
+	uint8_t mask = readRegister(REG_IRQ_FLAGS_MASK);
+	
+	if (debug >= 2) {
+		String response="";
+		
+		response +="<h2>System State and Interrupt</h2>";
+		
+		response +="<table class=\"config_table\">";
+		response +="<tr>";
+		response +="<th class=\"thead\">Parameter</th>";
+		response +="<th class=\"thead\">Value</th>";
+		response +="<th colspan=\"2\"  class=\"thead\">Set</th>";
+		response +="</tr>";
+		
+		response +="<tr><td class=\"cell\">_state</td>";
+		response +="<td class=\"cell\">";
+		switch (_state) {							// See loraModem.h
+			case S_INIT: response +="INIT"; break;
+			case S_SCAN: response +="SCAN"; break;
+			case S_CAD: response +="CAD"; break;
+			case S_RX: response +="RX"; break;
+			case S_TX: response +="TX"; break;
+			default: response +="unknown"; break;
+		}
+		response +="</td></tr>";
+
+		response +="<tr><td class=\"cell\">flags (8 bits)</td>";
+		response +="<td class=\"cell\">0x";
+		if (flags <16) response += "0";
+		response +=String(flags,HEX); response+="</td></tr>";
+
+		
+		response +="<tr><td class=\"cell\">mask (8 bits)</td>";
+		response +="<td class=\"cell\">0x"; 
+		if (mask <16) response += "0";
+		response +=String(mask,HEX); response+="</td></tr>";
+		
+		response +="<tr><td class=\"cell\">Re-entrant cntr</td>";
+		response +="<td class=\"cell\">"; 
+		response += String() + gwayConfig.reents;
+		response +="</td></tr>";
+
+		response +="<tr><td class=\"cell\">ntp call cntr</td>";
+		response +="<td class=\"cell\">"; 
+		response += String() + gwayConfig.ntps;
+		response+="</td></tr>";
+		
+		response +="<tr><td class=\"cell\">ntpErr cntr</td>";
+		response +="<td class=\"cell\">"; 
+		response += String() + gwayConfig.ntpErr;
+		response +="</td>";
+		response +="<td colspan=\"2\" style=\"border: 1px solid black;\">";
+		stringTime(gwayConfig.ntpErrTime, response);
+		response +="</td>";
+		response +="</tr>";
+		
+		response +="<tr><td class=\"cell\">Time Correction (uSec)</td><td class=\"cell\">"; 
+		response += txDelay; 
+		response +="</td>";
+		response +="<td class=\"cell\"><a href=\"DELAY=-1\"><button>-</button></a></td>";
+		response +="<td class=\"cell\"><a href=\"DELAY=1\"><button>+</button></a></td>";
+		response +="</tr>";
+		
+		response +="</table>";
+		
+		server.sendContent(response);
+	}// if debug>=2
+}
+
+
+// ----------------------------------------------------------------------------
+// STATISTICS DATA
+//
+// ----------------------------------------------------------------------------
+static void statisticsData()
+{
+	String response="";
+
+	response +="<h2>Package Statistics</h2>";
+	
+	response +="<table class=\"config_table\">";
+	response +="<tr>";
+	response +="<th class=\"thead\">Counter</th>";
+	response +="<th class=\"thead\">Pkgs</th>";
+	response +="<th class=\"thead\">Pkgs/hr</th>";
+	response +="</tr>";
+	
+	response +="<tr><td class=\"cell\">Packages Uplink Total</td>";
+		response +="<td class=\"cell\">" + String(cp_nb_rx_rcv) + "</td>";
+		response +="<td class=\"cell\">" + String((cp_nb_rx_rcv*3600)/(millis()/1000)) + "</td></tr>";
+	response +="<tr><td class=\"cell\">Packages Uplink OK </td><td class=\"cell\">";
+		response +=cp_nb_rx_ok; response+="</tr>";
+	response +="<tr><td class=\"cell\">Packages Downlink</td><td class=\"cell\">"; 
+		response +=cp_up_pkt_fwd; response+="</tr>";
+
+	// Privide a tbale with all the SF data including percentage of messsages
+#if STATISTICS >= 2
+	response +="<tr><td class=\"cell\">SF7 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf7; 
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf7/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+	response +="<tr><td class=\"cell\">SF8 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf8;
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf8/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+	response +="<tr><td class=\"cell\">SF9 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf9;
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf9/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+	response +="<tr><td class=\"cell\">SF10 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf10; 
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf10/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+	response +="<tr><td class=\"cell\">SF11 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf11; 
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf11/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+	response +="<tr><td class=\"cell\">SF12 rcvd</td>"; response +="<td class=\"cell\">"; response +=statc.sf12; 
+		response +="<td class=\"cell\">"; response += String(cp_nb_rx_rcv>0 ? 100*statc.sf12/cp_nb_rx_rcv : 0)+" %"; response +="</td></tr>";
+#endif
+
+	response +="</table>";
+
+	server.sendContent(response);
+}
+
+
+
+
+// ----------------------------------------------------------------------------
+// SENSORDATA
+// If enabled, display the sensorHistory on the current webserver Page.
+// Parameters:
+//	- <none>
+// Returns:
+//	- <none>
+// ----------------------------------------------------------------------------
+static void sensorData() 
+{
+#if STATISTICS >= 1
+	String response="";
+	
+	response += "<h2>Message History</h2>";
+	response += "<table class=\"config_table\">";
+	response += "<tr>";
+	response += "<th class=\"thead\">Time</th>";
+	response += "<th class=\"thead\">Node</th>";
+	response += "<th class=\"thead\" colspan=\"2\">Channel</th>";
+	response += "<th class=\"thead\" style=\"width: 50px;\">SF</th>";
+	response += "<th class=\"thead\" style=\"width: 50px;\">pRSSI</th>";
+#if RSSI==1
+	if (debug > 1) {
+		response += "<th class=\"thead\" style=\"width: 50px;\">RSSI</th>";
+	}
+#endif
+	response += "</tr>";
+	server.sendContent(response);
+
+	for (int i=0; i<MAX_STAT; i++) {
+		if (statr[i].sf == 0) break;
+		
+		response = "";
+		
+		response += String() + "<tr><td class=\"cell\">";
+		stringTime(statr[i].tmst, response);
+		response += "</td>";
+		response += String() + "<td class=\"cell\">";
+		printHEX((char *)(& (statr[i].node)),' ',response);
+		response += "</td>";
+		response += String() + "<td class=\"cell\">" + statr[i].ch + "</td>";
+		response += String() + "<td class=\"cell\">" + freqs[statr[i].ch] + "</td>";
+		response += String() + "<td class=\"cell\">" + statr[i].sf + "</td>";
+
+		response += String() + "<td class=\"cell\">" + statr[i].prssi + "</td>";
+#if RSSI==1
+		if (debug > 1) {
+			response += String() + "<td class=\"cell\">" + statr[i].rssi + "</td>";
+		}
+#endif
+		response += "</tr>";
+		server.sendContent(response);
+	}
+	
+	server.sendContent("</table>");
+	
+#endif
+}
+
+// ----------------------------------------------------------------------------
+// SYSTEMDATA
+//
+// ----------------------------------------------------------------------------
+static void systemData()
+{
+	String response="";
+	response +="<h2>System Status</h2>";
+	
+	response +="<table class=\"config_table\">";
+	response +="<tr>";
+	response +="<th class=\"thead\">Parameter</th>";
+	response +="<th class=\"thead\">Value</th>";
+	response +="<th colspan=\"2\" class=\"thead\">Set</th>";
+	response +="</tr>";
+	
+	response +="<tr><td style=\"border: 1px solid black; width:120px;\">Gateway ID</td>";
+	response +="<td class=\"cell\">";	
+	  if (MAC_array[0]< 0x10) response +='0'; response +=String(MAC_array[0],HEX);	// The MAC array is always returned in lowercase
+	  if (MAC_array[1]< 0x10) response +='0'; response +=String(MAC_array[1],HEX);
+	  if (MAC_array[2]< 0x10) response +='0'; response +=String(MAC_array[2],HEX);
+	  response +="FFFF"; 
+	  if (MAC_array[3]< 0x10) response +='0'; response +=String(MAC_array[3],HEX);
+	  if (MAC_array[4]< 0x10) response +='0'; response +=String(MAC_array[4],HEX);
+	  if (MAC_array[5]< 0x10) response +='0'; response +=String(MAC_array[5],HEX);
+	response+="</tr>";
+	
+
+	response +="<tr><td class=\"cell\">Free heap</td><td class=\"cell\">"; response+=ESP.getFreeHeap(); response+="</tr>";
+	response +="<tr><td class=\"cell\">ESP speed</td><td class=\"cell\">"; response+=ESP.getCpuFreqMHz(); 
+		response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"SPEED=80\"><button>80</button></a></td>";
+		response +="<td style=\"border: 1px solid black; width:40px;\"><a href=\"SPEED=160\"><button>160</button></a></td>";
+		response+="</tr>";
+#ifdef ESP32BUILD
+  {
+    char serial[13];
+    uint64_t chipid = ESP.getEfuseMac();
+    sprintf(serial,"%04X%08X", (uint16_t) (chipid>>32), (uint32_t) chipid);
+    response +="<tr><td class=\"cell\">ESP Chip ID</td><td class=\"cell\">"; response+=serial; response+="</tr>";
+  }
+#else
+  response +="<tr><td class=\"cell\">ESP Chip ID</td><td class=\"cell\">"; response+=ESP.getChipId(); response+="</tr>";
+#endif  
+	response +="<tr><td class=\"cell\">OLED</td><td class=\"cell\">"; response+=OLED; response+="</tr>";
+		
+#if STATISTICS>=1
+	response +="<tr><td class=\"cell\">WiFi Setups</td><td class=\"cell\">"; response+=gwayConfig.wifis; response+="</tr>";
+	response +="<tr><td class=\"cell\">WWW Views</td><td class=\"cell\">"; response+=gwayConfig.views; response+="</tr>";
+#endif
+
+	response +="</table>";
+	server.sendContent(response);
+}
+
+
+// ----------------------------------------------------------------------------
+// WIFIDATA
+// Display the most important Wifi parameters gathered
+//
+// ----------------------------------------------------------------------------
+static void wifiData()
+{
+	String response="";
+	response +="<h2>WiFi Config</h2>";
+
+	response +="<table class=\"config_table\">";
+
+	response +="<tr><th class=\"thead\">Parameter</th><th class=\"thead\">Value</th></tr>";
+	
+	response +="<tr><td class=\"cell\">WiFi host</td><td class=\"cell\">"; 
+#ifdef ESP32BUILD
+  response +=WiFi.getHostname(); response+="</tr>";
+#else
+	response +=wifi_station_get_hostname(); response+="</tr>";
+#endif
+
+	response +="<tr><td class=\"cell\">WiFi SSID</td><td class=\"cell\">"; 
+	response +=WiFi.SSID(); response+="</tr>";
+	
+	response +="<tr><td class=\"cell\">IP Address</td><td class=\"cell\">"; 
+	printIP((IPAddress)WiFi.localIP(),'.',response); 
+	response +="</tr>";
+	response +="<tr><td class=\"cell\">IP Gateway</td><td class=\"cell\">"; 
+	printIP((IPAddress)WiFi.gatewayIP(),'.',response); 
+	response +="</tr>";
+	response +="<tr><td class=\"cell\">NTP Server</td><td class=\"cell\">"; response+=NTP_TIMESERVER; response+="</tr>";
+	response +="<tr><td class=\"cell\">LoRa Router</td><td class=\"cell\">"; response+=_TTNSERVER; response+="</tr>";
+	response +="<tr><td class=\"cell\">LoRa Router IP</td><td class=\"cell\">"; 
+	printIP((IPAddress)ttnServer,'.',response); 
+	response +="</tr>";
+#ifdef _THINGSERVER
+	response +="<tr><td class=\"cell\">LoRa Router 2</td><td class=\"cell\">"; response+=_THINGSERVER; 
+	response += String() + ":" + _THINGPORT + "</tr>";
+	response +="<tr><td class=\"cell\">LoRa Router 2 IP</td><td class=\"cell\">"; 
+	printIP((IPAddress)thingServer,'.',response);
+	response +="</tr>";
+#endif
+	response +="</table>";
+
+	server.sendContent(response);
+}
+
+
+// ----------------------------------------------------------------------------
+// SEND WEB PAGE() 
+// Call the webserver and send the standard content and the content that is 
+// passed by the parameter.
+//
+// NOTE: This is the only place where yield() or delay() calls are used.
+//
+// ----------------------------------------------------------------------------
+void sendWebPage(const char *cmd, const char *arg)
+{
+	openWebPage(); yield();
+	
+	setVariables(cmd,arg); yield();
+
+	statisticsData(); yield();		 			// Node statistics
+	sensorData(); yield();						// Display the sensor history, message statistics
+	systemData(); yield();						// System statistics such as heap etc.
+	wifiData(); yield();						// WiFI specific parameters
+	
+	configData(); yield();						// Display web configuration
+	
+	interruptData(); yield();					// Display interrupts only when debug >= 2
+		
+	// Close the client connection to server
+	server.sendContent(String() + "<br><br />Click <a href=\"/HELP\">here</a> to explain Help and REST options<br>");
+	server.sendContent(String() + "</BODY></HTML>");
+	server.sendContent(""); yield();
+	
+	server.client().stop();
+}
+
+// ----------------------------------------------------------------------------
+// Used by timeout functions
+// This function only displays the standard homepage
+//	Note: This function is not actively used, as the page is renewed 
+//	by using a HTML meta setting of 60 seconds
+// ----------------------------------------------------------------------------
+static void renewWebPage()
+{
+	//Serial.println(F("Renew Web Page"));
+	//sendWebPage("","");
+	//return;
+}
+
+// ----------------------------------------------------------------------------
+// SetupWWW function called by main setup() program to setup webserver
+// It does actually not much more than installing the callback handlers
+// for messages sent to the webserver
+//
+// Implemented is an interface like:
+// http://<server>/<Variable>=<value>
+//
+// ----------------------------------------------------------------------------
+void setupWWW() 
+{
+	server.begin();									// Start the webserver
+	
+	// -----------------
+	// BUTTONS, define what should happen with the buttons we press on the homepage
+	
+	server.on("/", []() {
+		sendWebPage("","");							// Send the webPage string
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	
+	server.on("/HELP", []() {
+		sendWebPage("HELP","");					// Send the webPage string
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	
+	// Reset the statistics
+	server.on("/RESET", []() {
+		Serial.println(F("RESET"));
+		cp_nb_rx_rcv = 0;
+		cp_nb_rx_ok = 0;
+		cp_up_pkt_fwd = 0;
+#if STATISTICS >= 1
+		for (int i=0; i<MAX_STAT; i++) { statr[i].sf = 0; }
+#if STATISTICS >= 2
+		statc.sf7 = 0;
+		statc.sf8 = 0;
+		statc.sf9 = 0;
+		statc.sf10= 0;
+		statc.sf11= 0;
+		statc.sf12= 0;
+		
+		statc.resets= 0;
+		writeGwayCfg(CONFIGFILE);
+#endif
+#endif
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// Reset the boot counter
+	server.on("/BOOT", []() {
+		Serial.println(F("BOOT"));
+#if STATISTICS >= 2
+		gwayConfig.boots = 0;
+		gwayConfig.wifis = 0;
+		gwayConfig.views = 0;
+		gwayConfig.ntpErr = 0;					// NTP errors
+		gwayConfig.ntpErrTime = 0;				// NTP last error time
+		gwayConfig.ntps = 0;					// Number of NTP calls
+#endif
+		gwayConfig.reents = 0;					// Re-entrance
+
+		writeGwayCfg(CONFIGFILE);
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	server.on("/NEWSSID", []() {
+		sendWebPage("NEWSSID","");				// Send the webPage string
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// Set debug parameter
+	server.on("/DEBUG=-1", []() {				// Set debug level 0-2						
+		debug = (debug+3)%4;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/DEBUG=1", []() {
+		debug = (debug+1)%4;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	
+	// Set delay in microseconds
+	server.on("/DELAY=1", []() {
+		txDelay+=1000;
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/DELAY=-1", []() {
+		txDelay-=1000;
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+
+	// Spreading Factor setting
+	server.on("/SF=1", []() {
+		if (sf>=SF12) sf=SF7; else sf= (sf_t)((int)sf+1);
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/SF=-1", []() {
+		if (sf<=SF7) sf=SF12; else sf= (sf_t)((int)sf-1);
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// Frequency of the GateWay node
+	server.on("/FREQ=1", []() {
+		uint8_t nf = sizeof(freqs)/sizeof(int);	// Number of elements in array
+		if (ifreq==(nf-1)) ifreq=0; else ifreq++;
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/FREQ=-1", []() {
+		uint8_t nf = sizeof(freqs)/sizeof(int);	// Number of elements in array
+		if (ifreq==0) ifreq=(nf-1); else ifreq--;
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// Set CAD function off/on
+	server.on("/CAD=1", []() {
+		_cad=(bool)1;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/CAD=0", []() {
+		_cad=(bool)0;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// GatewayNode
+	server.on("/NODE=1", []() {
+#if GATEWAYNODE==1
+		gwayConfig.isNode =(bool)1;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+#endif
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/NODE=0", []() {
+#if GATEWAYNODE==1
+		gwayConfig.isNode =(bool)0;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+#endif
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+#if GATEWAYNODE==1	
+	// Framecounter of the Gateway node
+	server.on("/FCNT", []() {
+
+		frameCount=0; 
+		rxLoraModem();							// Reset the radion with the new frequency
+		writeGwayCfg(CONFIGFILE);
+
+		//sendWebPage("","");						// Send the webPage string
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+#endif
+	// WWW Page refresh function
+	server.on("/REFR=1", []() {					// WWW page auto refresh ON
+#if A_REFRESH==1
+		gwayConfig.refresh =1;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+#endif		
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/REFR=0", []() {					// WWW page auto refresh OFF
+#if A_REFRESH==1
+		gwayConfig.refresh =0;
+		writeGwayCfg(CONFIGFILE);				// Save configuration to file
+#endif
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	
+	// Switch off/on the HOP functions
+	server.on("/HOP=1", []() {
+		_hop=true;
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/HOP=0", []() {
+		_hop=false;
+		ifreq=0; 
+		freq=freqs[0]; 
+		rxLoraModem();
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+#ifndef ESP32BUILD
+	server.on("/SPEED=80", []() {
+		system_update_cpu_freq(80);
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+	server.on("/SPEED=160", []() {
+		system_update_cpu_freq(160);
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+#endif
+
+	// Update the sketch. Not yet implemented
+	server.on("/UPDATE=1", []() {
+#if A_OTA==1
+		updateOtaa();
+#endif
+		server.sendHeader("Location", String("/"), true);
+		server.send ( 302, "text/plain", "");
+	});
+
+	// -----------
+	// This section from version 4.0.7 defines what PART of the
+	// webpage is shown based on the buttons pressed by the user
+	// Maybe not all information should be put on the screen since it
+	// may take too much time to serve all information before a next
+	// package interrupt arrives at the gateway
+	
+	Serial.print(F("WWW Server started on port "));
+	Serial.println(A_SERVERPORT);
+	return;
+}
+
+#endif
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/loraFiles.h
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/loraFiles.h
@@ -1,0 +1,50 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-15
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+//	and many others.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains a number of compile-time settings that can be set on (=1) or off (=0)
+// The disadvantage of compile time is minor compared to the memory gain of not having
+// too much code compiled and loaded on your ESP8266.
+//
+// ----------------------------------------------------------------------------------------
+
+
+
+// Definition of the configuration record that is read at startup and written
+// when settings are changed.
+struct espGwayConfig {
+	uint16_t fcnt;				// =0 as init value	XXX Could be 32 bit in size
+	uint16_t boots;				// Number of restarts made by the gateway after reset
+	uint16_t resets;			// Number of statistics resets
+	uint16_t views;				// Number of sendWebPage() calls
+	uint16_t wifis;				// Number of WiFi Setups
+	uint16_t reents;			// Number of re-entrant interrupt handler calls
+	uint16_t ntpErr;			// Number of UTP requests that failed
+	uint16_t ntps;
+
+	uint32_t ntpErrTime;		// Record the time of the last NTP error
+	uint8_t ch;					// index to freqs array, freqs[ifreq]=868100000 default
+	uint8_t sf;					// range from SF7 to SF12
+	uint8_t debug;				// range 0 to 4
+	
+	bool cad;					// is CAD enabled?
+	bool hop;					// Is HOP enabled (Note: SHould be disabled)
+	bool isNode;				// Is gateway node enabled
+	bool refresh;				// Is WWW browser refresh enabled
+	
+	String ssid;				// SSID of the last connected WiFi Network
+	String pass;				// Password
+} gwayConfig;
+
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/loraModem.h
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/loraModem.h
@@ -1,0 +1,378 @@
+// 1-channel LoRa Gateway for ESP8266
+// Copyright (c) 2016, 2017 Maarten Westenberg version for ESP8266
+// Version 5.0.1
+// Date: 2017-11-14
+//
+// 	based on work done by Thomas Telkamp for Raspberry PI 1ch gateway
+//	and many other contributors.
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the MIT License
+// which accompanies this distribution, and is available at
+// https://opensource.org/licenses/mit-license.php
+//
+// Author: Maarten Westenberg (mw12554@hotmail.com)
+//
+// This file contains a number of compile-time settings and declarations that are
+// specific to the LoRa rfm95, sx1276, sx1272 radio of the gateway.
+//
+//
+// ------------------------------------------------------------------------------------
+
+// Our code should correct the server timing
+long txDelay= 0x00;								// delay time on top of server TMST
+
+#define SPISPEED 8000000						// was 50000/50KHz < 10MHz
+
+// Frequencies
+// Set center frequency. If in doubt, choose the first one, comment all others
+// Each "real" gateway should support the first 3 frequencies according to LoRa spec.
+
+int freqs [] = { 
+	868100000, 									// Channel 0, 868.1 MHz primary
+	868300000, 									// Channel 1, 868.3 MHz mandatory
+	868500000, 									// Channel 2, 868.5 MHz mandatory
+	867100000, 									// Channel 3, 867.1 MHz
+	867300000, 
+	867500000, 
+	867700000, 
+	867900000, 
+	868800000, 
+	869525000									// Channel, for responses gateway (10%)
+	// TTN defines an additional channel at 869.525Mhz using SF9 for class B. Not used
+};
+uint32_t  freq = freqs[0];
+uint8_t	 ifreq = 0;								// Channel Index
+
+
+
+// Set the structure for spreading factor
+enum sf_t { SF6=6, SF7, SF8, SF9, SF10, SF11, SF12 };
+
+// The state of the receiver. See Semtech Datasheet (rev 4, March 2015) page 43
+// The _state is of the enum type (and should be cast when used as a number)
+enum state_t { S_INIT=0, S_SCAN, S_CAD, S_RX, S_TX, S_TXDONE};
+
+volatile state_t _state;
+volatile uint8_t _event=0;
+
+// rssi is measured at specific moments and reported on others
+// so we need to store the current value we like to work with
+uint8_t _rssi;	
+
+// In order to make the CAD behaviour dynamic we set a variable
+// when the CAD functions are defined. Value of 3 is minimum frequencies a
+// gateway should support to be fully LoRa compliant.
+#define NUM_HOPS 3
+
+bool _cad= (bool) _CAD;	// Set to true for Channel Activity Detection, only when dio 1 connected
+bool _hop=false;		// experimental; frequency hopping. Only use when dio2 connected
+bool inHop=false;
+unsigned long nowTime=0;
+unsigned long hopTime=0;
+unsigned long msgTime=0;
+
+#if _PIN_OUT==1
+// Definition of the GPIO pins used by the Gateway for Hallard type boards
+struct pins {
+	uint8_t dio0=15;	// GPIO15 / D8. For the Hallard board shared between DIO0/DIO1/DIO2
+	uint8_t dio1=15;	// GPIO15 / D8. Used for CAD, may or not be shared with DIO0
+	uint8_t dio2=15;	// GPIO15 / D8. Used for frequency hopping, don't care
+	uint8_t ss=16;		// GPIO16 / D0. Select pin connected to GPIO16 / D0
+	uint8_t rst=0;		// GPIO0 / D3. Reset pin not used	
+	// MISO 12 / D6
+	// MOSI 13 / D7
+	// CLK  14 / D5
+} pins;
+#elif _PIN_OUT==2
+// For ComResult gateway PCB use the following settings
+struct pins {
+	uint8_t dio0=5;		// GPIO5 / D1. Dio0 used for one frequency and one SF
+	uint8_t dio1=4;		// GPIO4 / D2. Used for CAD, may or not be shared with DIO0
+	uint8_t dio2=0;		// GPIO0 / D3. Used for frequency hopping, don't care
+	uint8_t ss=15;		// GPIO15 / D8. Select pin connected to GPIO15
+	uint8_t rst=0;		// GPIO0 / D3. Reset pin not used	
+} pins;
+#elif _PIN_OUT==3
+// For ComResult gateway PCB use the following settings
+struct pins {
+  uint8_t dio0=26;   // GPIO5 / D1. Dio0 used for one frequency and one SF
+  uint8_t dio1=33;   // GPIO4 / D2. Used for CAD, may or not be shared with DIO0
+  uint8_t dio2=32;   // GPIO0 / D3. Used for frequency hopping, don't care
+  uint8_t ss=18;    // GPIO15 / D8. Select pin connected to GPIO15
+  uint8_t rst=14;    // GPIO0 / D3. Reset pin not used 
+// Pin definetion of WIFI LoRa 32
+// HelTec AutoMation 2017 support@heltec.cn 
+#define SCK     5    // GPIO5  -- SX127x's SCK
+#define MISO    19   // GPIO19 -- SX127x's MISO
+#define MOSI    27   // GPIO27 -- SX127x's MOSI
+#define SS      18   // GPIO18 -- SX127x's CS
+#define RST     14   // GPIO14 -- SX127x's RESET
+#define DIO0    26   // GPIO26 -- SX127x's IRQ(Interrupt Request)  
+} pins;
+#else
+	// Use your own pin definitions, and uncomment #error line below
+	// MISO 12 / D6
+	// MOSI 13 / D7
+	// CLK  14 / D5
+	// SS   16 / D0
+#error "Pin Definitions _PIN_OUT must be 1(HALLARD) or 2 (COMRESULT)"
+#endif
+
+// STATR contains the statictis that are kept by message. 
+// Ech time a message is received or sent the statistics are updated.
+// In case STATISTICS==1 we define the last MAX_STAT messages as statistics
+struct stat_t {
+	unsigned long tmst;						// Time since 1970 in milli seconds		
+	unsigned long node;						// 4-byte DEVaddr (the only one known to gateway)
+	uint8_t ch;								// Channel index to freqs array
+	uint8_t sf;
+#if RSSI==1
+	int8_t rssi;							// XXX Can be < -128
+#endif
+	int8_t prssi;							// XXX Can be < -128	
+} stat_t;
+
+
+#if STATISTICS >= 1
+// History of received uplink messages from nodes
+struct stat_t statr[MAX_STAT];
+
+// STATC contains the statistic that are gateway related and not per
+// message. Example: Number of messages received on SF7 or number of (re) boots
+// So where statr contains the statistics gathered per packet the statc
+// contains general statics of the node
+#if STATISTICS >= 2							// Only if we explicitely set it higher
+struct stat_c {
+	unsigned long sf7;						// Spreading factor 7
+	unsigned long sf8;						// Spreading factor 8
+	unsigned long sf9;						// Spreading factor 9
+	unsigned long sf10;						// Spreading factor 10
+	unsigned long sf11;						// Spreading factor 11
+	unsigned long sf12;						// Spreading factor 12
+	
+	uint16_t boots;							// Number of boots
+	uint16_t resets;
+} stat_c;
+struct stat_c statc;
+#endif
+#else // STATISTICS==0
+struct stat_t statr[1];						// Always have at least one element to store in
+#endif
+
+// Define the payload structure used to separate interrupt ans SPI
+// processing from the loop() part
+uint8_t payLoad[128];			// Payload i
+struct LoraBuffer {
+	uint8_t * payLoad;
+	uint8_t payLength;
+	uint32_t tmst;
+	uint8_t sfTx;
+	uint8_t powe;
+	uint32_t fff;
+	uint8_t crc;
+	uint8_t iiq;
+} LoraDown;
+
+// Up buffer (from Lora to UDP)
+//
+
+struct LoraUp {
+	uint8_t payLoad[128];
+	uint8_t payLength;
+	int prssi; 
+	long snr;
+	int rssicorr;
+	uint8_t sf;
+} LoraUp;
+
+
+
+
+// ----------------------------------------
+// Used by REG_PAYLOAD_LENGTH to set receive payload length
+#define PAYLOAD_LENGTH              0x40	// 64 bytes
+#define MAX_PAYLOAD_LENGTH          0x80	// 128 bytes
+
+// Do not change these setting for RSSI detection. They are used for CAD
+// Given the correction factor of 157, we can get to -120dB with this rating
+// 
+#define RSSI_LIMIT	37							// was 39
+#define RSSI_LIMIT_DOWN 34						// Was 34
+
+// How long to wait in LoRa mode before using the RSSI value.
+// This period should be as short as possible, yet sufficient
+// 
+#define RSSI_WAIT	15							// was 100 works, 50 works, 40 works, 25 works
+#define RSSI_WAIT_DOWN 10						// was 75 works, 35 works, 30 works, 20 works
+
+// ============================================================================
+// Set all definitions for Gateway
+// ============================================================================	
+// Register definitions. These are the addresses of the TFM95, SX1276 that we 
+// need to set in the program.
+
+#define REG_FIFO                    0x00
+#define REG_OPMODE                  0x01
+// Register 2 to 5 are unused for LoRa
+#define REG_FRF_MSB					0x06
+#define REG_FRF_MID					0x07
+#define REG_FRF_LSB					0x08
+#define REG_PAC                     0x09
+#define REG_PARAMP                  0x0A
+#define REG_LNA                     0x0C
+#define REG_FIFO_ADDR_PTR           0x0D
+#define REG_FIFO_TX_BASE_AD         0x0E
+#define REG_FIFO_RX_BASE_AD         0x0F
+
+#define REG_FIFO_RX_CURRENT_ADDR    0x10
+#define REG_IRQ_FLAGS_MASK          0x11
+#define REG_IRQ_FLAGS               0x12
+#define REG_RX_NB_BYTES             0x13
+#define REG_PKT_SNR_VALUE			0x19
+#define REG_PKT_RSSI				0x1A	// latest package
+#define REG_RSSI					0x1B	// Current RSSI, section 6.4, or  5.5.5
+#define REG_HOP_CHANNEL				0x1C
+#define REG_MODEM_CONFIG1           0x1D
+#define REG_MODEM_CONFIG2           0x1E
+#define REG_SYMB_TIMEOUT_LSB  		0x1F
+
+#define REG_PAYLOAD_LENGTH          0x22
+#define REG_MAX_PAYLOAD_LENGTH 		0x23
+#define REG_HOP_PERIOD              0x24
+#define REG_MODEM_CONFIG3           0x26
+#define REG_RSSI_WIDEBAND			0x2C
+
+#define REG_INVERTIQ				0x33
+#define REG_DET_TRESH				0x37	// SF6
+#define REG_SYNC_WORD				0x39
+#define REG_TEMP					0x3C
+
+#define REG_DIO_MAPPING_1           0x40
+#define REG_DIO_MAPPING_2           0x41
+#define REG_VERSION	  				0x42
+
+#define REG_PADAC					0x5A
+#define REG_PADAC_SX1272			0x5A
+#define REG_PADAC_SX1276			0x4D
+
+
+// ----------------------------------------
+// opModes
+#define SX72_MODE_SLEEP             0x80
+#define SX72_MODE_STANDBY           0x81
+#define SX72_MODE_FSTX              0x82
+#define SX72_MODE_TX                0x83	// 0x80 | 0x03
+#define SX72_MODE_RX_CONTINUOS      0x85
+
+// ----------------------------------------
+// LMIC Constants for radio registers
+#define OPMODE_LORA      			0x80
+#define OPMODE_MASK      			0x07
+#define OPMODE_SLEEP     			0x00
+#define OPMODE_STANDBY   			0x01
+#define OPMODE_FSTX      			0x02
+#define OPMODE_TX        			0x03
+#define OPMODE_FSRX      			0x04
+#define OPMODE_RX        			0x05
+#define OPMODE_RX_SINGLE 			0x06
+#define OPMODE_CAD       			0x07
+
+
+
+// ----------------------------------------
+// LOW NOISE AMPLIFIER
+
+#define LNA_MAX_GAIN                0x23
+#define LNA_OFF_GAIN                0x00
+#define LNA_LOW_GAIN		    	0x20
+
+// CONF REG
+#define REG1                        0x0A
+#define REG2                        0x84
+
+// ----------------------------------------
+// MC1 sx1276 RegModemConfig1
+#define SX1276_MC1_BW_125           0x70
+#define SX1276_MC1_BW_250           0x80
+#define SX1276_MC1_BW_500           0x90
+#define SX1276_MC1_CR_4_5           0x02
+#define SX1276_MC1_CR_4_6           0x04
+#define SX1276_MC1_CR_4_7           0x06
+#define SX1276_MC1_CR_4_8           0x08
+#define SX1276_MC1_IMPLICIT_HEADER_MODE_ON  0x01
+
+#define SX72_MC1_LOW_DATA_RATE_OPTIMIZE     0x01 	// mandated for SF11 and SF12
+
+// ----------------------------------------
+// MC2 definitions
+#define SX72_MC2_FSK                0x00
+#define SX72_MC2_SF7                0x70		// SF7 == 0x07, so (SF7<<4) == SX7_MC2_SF7
+#define SX72_MC2_SF8                0x80
+#define SX72_MC2_SF9                0x90
+#define SX72_MC2_SF10               0xA0
+#define SX72_MC2_SF11               0xB0
+#define SX72_MC2_SF12               0xC0
+
+// ----------------------------------------
+// MC3
+#define SX1276_MC3_LOW_DATA_RATE_OPTIMIZE  0x08
+#define SX1276_MC3_AGCAUTO                 0x04
+
+// ----------------------------------------
+// FRF
+#define FRF_MSB						0xD9		// 868.1 Mhz
+#define FRF_MID						0x06
+#define FRF_LSB						0x66
+
+// ----------------------------------------
+// DIO function mappings           		     D0D1D2D3
+#define MAP_DIO0_LORA_RXDONE   		0x00  // 00------ bit 7 and 6
+#define MAP_DIO0_LORA_TXDONE   		0x40  // 01------
+#define MAP_DIO0_LORA_CADDONE  		0x80  // 10------
+#define MAP_DIO0_LORA_NOP   		0xC0  // 11------
+
+#define MAP_DIO1_LORA_RXTOUT   		0x00  // --00---- bit 5 and 4
+#define MAP_DIO1_LORA_FCC			0x10  // --01----
+#define MAP_DIO1_LORA_CADDETECT		0x20  // --10----
+#define MAP_DIO1_LORA_NOP      		0x30  // --11----
+
+#define MAP_DIO2_LORA_FCC0      	0x00  // ----00-- bit 3 and 2
+#define MAP_DIO2_LORA_FCC1      	0x04  // ----01-- bit 3 and 2
+#define MAP_DIO2_LORA_FCC2      	0x08  // ----10-- bit 3 and 2
+#define MAP_DIO2_LORA_NOP      		0x0C  // ----11-- bit 3 and 2
+
+#define MAP_DIO3_LORA_CADDONE  		0x00  // ------00 bit 1 and 0
+#define MAP_DIO3_LORA_NOP      		0x03  // ------11
+
+#define MAP_DIO0_FSK_READY     		0x00  // 00------ (packet sent / payload ready)
+#define MAP_DIO1_FSK_NOP       		0x30  // --11----
+#define MAP_DIO2_FSK_TXNOP     		0x04  // ----01--
+#define MAP_DIO2_FSK_TIMEOUT   		0x08  // ----10--
+
+// ----------------------------------------
+// Bits masking the corresponding IRQs from the radio
+#define IRQ_LORA_RXTOUT_MASK 		0x80
+#define IRQ_LORA_RXDONE_MASK 		0x40
+#define IRQ_LORA_CRCERR_MASK 		0x20
+#define IRQ_LORA_HEADER_MASK 		0x10
+#define IRQ_LORA_TXDONE_MASK 		0x08
+#define IRQ_LORA_CDDONE_MASK 		0x04
+#define IRQ_LORA_FHSSCH_MASK 		0x02
+#define IRQ_LORA_CDDETD_MASK 		0x01
+
+
+// ----------------------------------------
+// Definitions for UDP message arriving from server
+#define PROTOCOL_VERSION			0x01
+#define PKT_PUSH_DATA				0x00
+#define PKT_PUSH_ACK				0x01
+#define PKT_PULL_DATA				0x02
+#define PKT_PULL_RESP				0x03
+#define PKT_PULL_ACK				0x04
+#define PKT_TX_ACK                  0x05
+
+#define MGT_RESET					0x15	// Not a LoRa Gateway Spec message
+#define MGT_SET_SF					0x16
+#define MGT_SET_FREQ				0x17
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/testing.md
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/ESP-sc-gway/testing.md
@@ -1,0 +1,28 @@
+#Testing the Gateway
+
+## Introduction
+
+This document describes the testing of the single channel gateway. These parameters are set in gthe loraModem.h file and determine its behaviour for switching from S_SCAN state to S_CAD state and the fallback from S_CAD state to scanning if the rssi drop dramatically.
+
+## Optimize for STD
+
+For the standard mode, the folowing values are used for parameter setting:
+
+- RSSI_LIMIT 40
+- RSSI_WAIT	 275
+- 
+
+## Optimize for CAD
+
+For the standard mode, the folowing values are used for parameter setting:
+
+
+## Optimize for HOP
+
+For the HOP mode, the folowing values are used for parameter setting:
+
+- RSSI_LIMIT 39 for the S_SCAN state, and -5 for the S_CAD state
+- RSSI_WAIT	 250
+- RSSI_WAIT_DOWN 225; microseconds to wait before reading RSSI when in S_CAD mode to decide going back to S_SCAN
+- 
+

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/LICENSE
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 things4u
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/README.md
+++ b/Gateway/TTGO_ESP32_v1/ESP-1ch-Gateway-v5.0_ESP32/README.md
@@ -1,0 +1,337 @@
+# Single Channel LoRaWAN Gateway
+
+Version 5.0.1, November, 2017  
+Author: M. Westenberg (mw12554@hotmail.com)  
+Copyright: M. Westenberg (mw12554@hotmail.com)  
+
+All rights reserved. This program and the accompanying materials are made available under the terms 
+of the MIT License which accompanies this distribution, and is available at
+https://opensource.org/licenses/mit-license.php  
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Maintained by Maarten Westenberg (mw12554@hotmail.com)
+
+Changes for ESP32 by Jac Kersing, don't blame Maarten...
+See the note at the end for what (should) work.
+
+# Description
+
+This repository contains a proof-of-concept implementation of a single channel LoRaWAN gateway for the ESP8266.
+The software implements a standard LoRa gateway with the following exceptions on changes:
+
+-  This LoRa gateway is not a full gateway but it implements just a one-channel/one frequency gateway. 
+The minimum amount of frequencies supported by a full gateway is 3, most support 9 or more frequencies.
+This software started as a proof-of-concept to prove that a single low-cost RRFM95 chip which was present in almost every
+LoRa node in Europe could be used as a cheap alternative to the far more expensive full gateways that were 
+making use of the SX1301 chip.
+
+- As the software of this gateway will often be used during the development phase of a project or in demo situations, 
+the software is flexible and can be easily configured according to environment or customer requirements. 
+There are two ways of interacting with the software: 1. Modifying the ESP-sc-gway.h file at compile time allows the 
+administrator to set almost all parameters. 2. Using the webinterface (http://<gateway_IP>) will allow 
+administrators to set and reset several of the parameters at runtime.
+
+
+## testing
+
+The single channel gateway has been tested on a gateway with the Wemos D1 Mini, using a HopeRF RFM95W transceiver.  
+The LoRa nodes tested are:
+
+- TeensyLC with HopeRF RFM95 radio
+- Arduino Pro-Mini (default Armega328 model, 8MHz 3.3V and 16MHz 3.3V)
+- ESP8266 based nodes with RFM95 transceivers.
+
+
+# Getting Started
+
+It is recommended to compile and start the single channel gateway with as little modificatons as possible. 
+This means that you should use the default settings in the configuration files as much as possible and 
+only change the SSID/Password for your WiFi setup and the pins of your ESP8266 that you use in loraModem.h.
+This section describes the minimum of configuration necessary to get a working gateway which than can be 
+configured further using the webpage.
+
+1. Unpack the source code including the libraries in a separate folder.
+2. Connect the gateway to a serial port of your computer, and configure that port in the IDE. 
+Switch on the Serial Monitor for the gateway. As the Wemos chip does not contain any code, you will probably 
+see nothing on the Serial Monitor.
+3. Modify the _loraModem.h file and change the "struct pins" area and configure either for a traditional
+(=Comresult) PCB or configure for a Hallard PCB where the dio0, dio1 and dio2 pins are shared. You HAVE to check 
+this section.
+4. Edit the ESP-sc-gway.h file and adapt the "wpas" structure. `Make sure that the first line of this structure 
+remains empty and put the SSID and Password of your router on the second line of the array.
+5. Compile the code and doenload the executable over USB to the gateway. If all is right, you should
+see the gateway starting up on the Serial Monitor.
+6. Note the IP address that the device receives from your router. Use that IP address in a browser on 
+your computer to connect to the gateway with the browser.
+
+Now your gateway should be running. Use the webpage to set "debug" to 1 and you should be able to see packages
+coming in on the Serial monitor.
+
+
+# Configuration
+
+There are two ways of changing the configuration of the single channel gateway:
+
+1. Changing the ESP-sc-gway.h file at compile-time
+2. Run the http://<gateway-IP> web interface to change setting at complie time.
+
+
+## Editing the ESP-sc-gway.h file
+
+The ESP-sc-gway.h file contains all the user configurable settings. All have their definitions set through #define statements. 
+In general, setting a #define to 1 will enable the function and setting it to 0 will disable it. 
+
+Also, some settings cn be initialised by setting their value with a #define but can be changed at runtime in the web interface.
+For some settings, disabling the function with a #define will remove the function from the webserver as well.
+
+NOTE regarding memory usage: The ESP8266 has an enormous amount of memory available for program space and SPIFFS filesystem. 
+However the memory available for heap and variables is limited to about 80K bytes (For the ESP-32 this is higher). 
+The user is advised to turn off functions not used in order to save on memory usage. 
+If the heap drops below 18 KBytes some functions may not behave as expected (in extreme case the program may crash).
+
+
+### Debug
+
+The user can set the initial value of the DEBUG parameter. 
+Setting this parameter will also detemine some settings of the webserver.
+
+ \#define DEBUG 1
+
+ 
+### Setting Spreading Factor
+
+Set the _SPREADING factor to the desired SF7, SF8 - SF12 value. 
+Please note that this value is closely related to teh value used for _CAD. 
+If _CAD is enabled, the value of _SPREADING is not used by the gateway as it has all sreading factors enabled.
+
+ \#define _SPREADING SF9
+ 
+Please note that the default frequency used is 868.1 MHz which can be changed in the loraModem.h file. 
+The user is advised NOT to change this etting and only use the default 868.1 MHz frequency.
+
+
+### Channel Activity Detection
+
+Channel Activity Detection (CAD) is a function of the LoRa RFM95 chip to detect incoming messages (activity). 
+These incoming messages might arrive on any of the well know spreading factors SF7-SF12. 
+By enabling CAD, the gateway can receive messages of any of the spreading factors.
+
+Actually it is used in normal operation to tell the receiver that another signal is using the 
+channel already.
+
+The CAD functionality comes at a (little) price: The chip will not be able to receive very weak signals as 
+the CAD function will use the RSSI register setting of the chip to determine whether or not it received a 
+signal (or just noise). As a result, very weak signals are not received which means that the range of the 
+gateway will be reduced in CAD mode.
+
+ \#define _CAD 1
+
+ 
+### Over the Air Updates (OTA)
+
+As from version 4.0.6 the gateway allows over the air updated if the setting A_OTA is on. 
+The over the air software requires once setting of the 4.0.6 version over USB to the gateway,
+after which the software is (default) enabled for use.
+
+The first release only supports OTA function using the IDE which in practice means the IDE has to 
+be on the same network segment as the gateway.
+
+Note: You have to use Bonjour software (Apple) on your network somewhere. A version is available
+for most platforms (shipped with iTunes for windows for example). The Bonjour software enables the
+gateway to use mDNS to resolve the gateway ID set by OTA after which download ports show up in the IDE.
+
+Todo: The OTA software has not (yet) been tested in conjuction with the WiFiManager software.
+
+ \#define A_OTA 1  
+
+
+
+### Enable Webserver
+
+This setting enables the webserver. Although the webserver itself takes a lot of memory, it greatly helps 
+to configure the gatewayat run-time and inspects its behaviour. It also provides statistics of last messages received.
+The A_REFRESH parameter defines whether the webserver should renew every X seconds.
+
+ \#define A_SERVER 1				// Define local WebServer only if this define is set  
+ \#define A_REFRESH 0				// Will the webserver refresh or not?  
+ \#define A_SERVERPORT 80			// local webserver port  
+ \#define A_MAXBUFSIZE 192			// Must be larger than 128, but small enough to work  
+
+ The A_REFRESH parameter determines the refresh frequency of the webserver.  
+ 
+### Strict LoRa behaviour
+
+In order to have the gateway send downlink messages on the pre-set spreading factor and on the default frequency, 
+you have to set the _STRICT_1Ch parameter to 1. Note that when it is not set to 1, the gateway will respond to 
+downlink requests with the frequency and spreading factor set by the backend server. And at the moment TTN 
+responds to downlink messages for SF9-SF12 in the RX2 timeslot and with frequency 869.525MHz and on SF12 
+(according to the LoRa standard when sending in the RX2 timeslot). 
+
+ \#define _STRICT_1CH 0
+
+You are advised not to change the default setting of this parameter.
+
+### Enable OLED panel
+
+By setting the OLED you configure the system to work with OLED panels over I2C.
+Some panels work by both SPI and I2C where I2c is solwer. However, since SPI is use for RFM95 transceiver 
+communication you are stronly discouvared using one of these as they will not work with this software.
+Instead choose a OLED solution that works over I2C.
+
+ \#define OLED 1
+ 
+Setting the I2C SDA/SCL pins is done in the ESP-sc-gway.h file right after the #define of OLED.
+Standard the ESP8266 uses pins D1 and D2 for the I2C bus SCL and SDA lines but these can be changed by the user.
+Normally thsi is not necessary. 
+The OLED functions are found in the _loraModem.ino file, and can be adapted to show other fields. 
+The functions are called when a message is received(!) and therefore potentionally this will add to the
+instability of the ESP as these functions may require more time than expected.
+If so, swithc off the OLED function or build in a function in the main loop() that displays in user time 
+(not interrupt).
+
+### Setting TTN server
+
+The gateway allows to connect to 2 servers at the same time (as most LoRa gateways do BTW). 
+You have to connect to at least one standard LoRa router, in case you use The Things Network (TTN) 
+than make sure that you set:
+
+ \#define _TTNSERVER "router.eu.thethings.network"  
+ \#define _TTNPORT 1700  
+  
+In case you setup your own server, you can specify as follows using your own router URL and your own port:
+
+ \#define _THINGSERVER "your_server.com"			// Server URL of the LoRa udp.js server program  
+ \#define _THINGPORT 1701							// Your UDP server should listen to this port  
+
+ 
+### Gateway Identity
+Set the identity parameters for your gateway:   
+
+\#define _DESCRIPTION "ESP-Gateway"  
+\#define _EMAIL "your.email@provider.com"  
+\#define _PLATFORM "ESP8266"  
+\#define _LAT 52.00  
+\#define _LON 5.00  
+\#define _ALT 0  
+
+
+### Using the gateway as a sensor node
+
+It is possible to use the gateway as a node. This way, local/internal sensor values are reported.
+This is a cpu and memory intensive function as making a sensor message involves EAS and CMAC functions.
+
+ \#define GATEWAYNODE 0  
+
+Further below in the configuration file, it is possible to set the address and other  LoRa information of the gateway node.
+
+ \#if GATEWAYNODE==1  
+ \#define _DEVADDR { 0x26, 0x01, 0x15, 0x3D }  
+ \#define _APPSKEY { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }  
+ \#define _NWKSKEY { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }  
+ \#define _SENSOR_INTERVAL 300  
+ \#endif  
+
+
+### Connect to WiFi with WiFiManager
+
+The easiest way to configure the Gateway on WiFi is by using the WiFimanager function. This function works out of the box. 
+WiFiManager will put the gateway in accesspoint mode so that you can connect to it as a WiFi accesspoint. 
+
+ \#define WIFIMANAGER 0  
+
+If Wifi Manager is enabled, make sure to define the name of the accesspoint if the gateway is in accesspoint 
+mode and the password.
+
+ \#define AP_NAME "ESP8266-Gway-Things4U"  
+ \#define AP_PASSWD "ttnAutoPw"  
+
+The standard access point name used by the gateway is "ESP8266 Gway" and its password is "ttnAutoPw". 
+After binding to the access point with your mobile phone or computer, go to htp://192.168.4.1 in a browser and tell the gateway to which WiFi network you want it to connect, and specify the password.
+
+The gateway will then reset and bind to the given network. If all goes well you are now set and the ESP8266 will remember the network that it must connect to. NOTE: As long as the accesspoint that the gateway is bound to is present, the gateway will not any longer work with the wpa list of known access points.
+If necessary, you can delete the current access point in the webserver and power cycle the gateway to force it to read the wpa array again.
+
+
+### Other Settings
+
+- static char *wpa[WPASIZE][2] contains the array of known WiFi access points the Gateway will connect to.
+Make sure that the dimensions of the array are correctly defined in the WPASIZE settings. 
+Note: When the WiFiManager software is enabled (it is by default) there must at least be one entry in the wpa file, wpa[0] is used for storing WiFiManager information.
+- Only the sx1276 (and HopeRF 95) radio modules are supported at this time. The sx1272 code should be 
+working without much work, but as I do not have one of these modules available I cannot test this.
+
+
+## Webserver
+
+The built-in webserver can be used to display status and debugging information. 
+Also the webserver allows the user to change certain settings at run-time such as the debug level or switch on 
+and off the CAD function.
+It can be accessed with the following URL: http://<YourGatewayIP>:80 where <YourGatewayIP> is the IP given by 
+the router to the ESP8266 at startup. It is probably something like 192.168.1.XX
+The webserver shows various configuration settings as well as providing functions to set parameters.
+
+The following parameters can be set using the webServer. 
+- Debug Level (0-4)
+- CAD mode on or off (STD mode)
+- Switch frequency hopping on and off (Set to OFF)
+- When frequency Hopping is off: Select the frequency the gateway will work with. 
+NOTE: Frequency hopping is experimental and does not work correctly.
+- When CAD mode is off: Select the Spreading Factor (SF) the gateway will work with
+
+
+# Dependencies
+
+The software is dependent on several pieces of software, the Arduino IDE for ESP8266 
+being the most important. Several other libraries are also used by this program, 
+make sure you install those libraries with the IDE:
+
+- gBase64 library, The gBase library is actually a base64 library made 
+	by Adam Rudd (url=https://github.com/adamvr/arduino-base64). I changed the name because I had
+	another base64 library installed on my system and they did not coexist well.
+- Time library (http://playground.arduino.cc/code/time)
+- Arduino JSON; Needed to decode downstream messages
+- SimpleTimer; ot yet used, but reserved for interrupt and timing
+- WiFiManager
+- ESP8266 Web Server
+- Streaming library, used in the wwwServer part
+- AES library (taken from ideetron.nl) for downstream messages
+- Time
+
+For convenience, the libraries are also found in this github repository in the libraries directory. 
+Please note that they are NOT part of the ESP 1channel gateway and may have their own licensing.
+However, these libraries are not part of the single-channel Gateway software.
+
+
+# Connections
+
+See http://things4u.github.io in the hardware section for building and connection instructions.
+
+
+# To-DO
+
+The following things are still on my wish list to make to the single channel gateway:  
+
+- Receive downstream message with commands form the server. These can be used to configure
+  the gateway through downlink messages (such as setting the SF)
+- Support for ESP32 (partially done, see below) and RFM95 on 915 MHz
+- Use the SPIFFS for storing .css files
+- Use the SPIFFS for storing node data (for later analysis)
+
+
+# ESP32 Specifics
+
+Not all features are supported for ESP32 (yet). Missing are:
+- OTA
+- WiFiManager
+- GATEWAYMGT (manage gateway over UDP)
+
+Untested features:
+- GATEWAYNODE : use gateway as sensor node
+- REPEATER
+
+
+# License
+
+The source files of the gateway sketch in this repository is made available under the MIT
+license. The libraries included in this repository are included for convenience only and all have their own license, and are not part of the ESP 1ch gateway code.

--- a/Nodo/TTGO_ESP32_v1/ttn-abp/ttn-abp.ino
+++ b/Nodo/TTGO_ESP32_v1/ttn-abp/ttn-abp.ino
@@ -1,0 +1,328 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Thomas Telkamp and Matthijs Kooijman
+ *
+ * Permission is hereby granted, free of charge, to anyone
+ * obtaining a copy of this document and accompanying files,
+ * to do whatever they want with them without any restriction,
+ * including, but not limited to, copying, modification and redistribution.
+ * NO WARRANTY OF ANY KIND IS PROVIDED.
+ *
+ * This example sends a valid LoRaWAN packet with payload "Hello,
+ * world!", using frequency and encryption settings matching those of
+ * the The Things Network.
+ *
+ * This uses ABP (Activation-by-personalisation), where a DevAddr and
+ * Session keys are preconfigured (unlike OTAA, where a DevEUI and
+ * application key is configured, while the DevAddr and session keys are
+ * assigned/generated in the over-the-air-activation procedure).
+ *
+ * Note: LoRaWAN per sub-band duty-cycle limitation is enforced (1% in
+ * g1, 0.1% in g2), but not the TTN fair usage policy (which is probably
+ * violated by this sketch when left running for longer)!
+ *
+ * To use this sketch, first register your application and device with
+ * the things network, to set or generate a DevAddr, NwkSKey and
+ * AppSKey. Each device should have their own unique values for these
+ * fields.
+ *
+ * Do not forget to define the radio type correctly in config.h.
+ *
+ *******************************************************************************/
+
+#include <lmic.h>
+#include <hal/hal.h>
+#include <SPI.h>
+
+#define OLED 1 // Set to 1 to enable OLED SSD1306 display
+#define SINGLE_CHANNEL 1 // Set to 1 to force single channel node
+
+#define BUILTIN_LED 25
+
+#if OLED == 1
+#include <U8x8lib.h>
+ // the OLED used
+U8X8_SSD1306_128X64_NONAME_SW_I2C u8x8 (/* clock=*/ 15, /* data=*/ 4, /* reset=*/ 16);
+#endif // OLED
+
+// LoRaWAN NwkSKey, network session key
+// This is the default Semtech key, which is used by the early prototype TTN
+// network.
+static const PROGMEM u1_t NWKSKEY[16] = { 0x21, 0x0E, 0x83, 0xB8, 0x7C, 0x66, 0x4B, 0x6A, 0x2C, 0xE1, 0x3F, 0x4D, 0x47, 0xB7, 0x39, 0x12 };
+
+// LoRaWAN AppSKey, application session key
+// This is the default Semtech key, which is used by the early prototype TTN
+// network.
+static const u1_t PROGMEM APPSKEY[16] = { 0x54, 0x00, 0xF3, 0x75, 0xFD, 0x1A, 0x22, 0xB3, 0x26, 0x07, 0xA9, 0x83, 0xA8, 0x64, 0x8F, 0xBD };
+
+// LoRaWAN end-device address (DevAddr)
+static const u4_t DEVADDR = 0x26011910; //0x05FF0001 ; // <-- Change this address for every node!
+
+// These callbacks are only used in over-the-air activation, so they are
+// left empty here (we cannot leave them out completely unless
+// DISABLE_JOIN is set in config.h, otherwise the linker will complain).
+void os_getArtEui (u1_t* buf) { }
+void os_getDevEui (u1_t* buf) { }
+void os_getDevKey (u1_t* buf) { }
+
+static uint8_t mydata[] = "Hello, world!";
+static osjob_t sendjob;
+
+// Schedule TX every this many seconds (might become longer due to duty
+// cycle limitations).
+const unsigned TX_INTERVAL = 300;
+
+// Pin mapping for TTGO ESP32 v1
+const lmic_pinmap lmic_pins = {
+	.nss = 18,
+	.rxtx = LMIC_UNUSED_PIN,
+	.rst = 14,
+	.dio = {/*dio0*/ 26, /*dio1*/ 33, /*dio2*/ 32 }
+};
+
+void onEvent (ev_t ev) {
+	Serial.print (os_getTime ());
+
+#if OLED == 1
+	u8x8.setCursor (0, 3);
+	u8x8.printf ("%0x", LMIC.devaddr);
+	u8x8.setCursor (0, 5);
+	u8x8.printf ("TIME %lu", os_getTime ());
+#endif // OLED
+
+	Serial.print (": ");
+	switch (ev) {
+	case EV_SCAN_TIMEOUT:
+		Serial.println (F ("EV_SCAN_TIMEOUT"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_SCAN_TIMEOUT");
+#endif // OLED
+		break;
+	case EV_BEACON_FOUND:
+		Serial.println (F ("EV_BEACON_FOUND"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_BEACON_FOUND");
+#endif // OLED
+		break;
+	case EV_BEACON_MISSED:
+		Serial.println (F ("EV_BEACON_MISSED"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_BEACON_MISSED");
+#endif // OLED
+		break;
+	case EV_BEACON_TRACKED:
+		Serial.println (F ("EV_BEACON_TRACKED"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_BEACON_TRACKED");
+#endif // OLED
+		break;
+	case EV_JOINING:
+		Serial.println (F ("EV_JOINING"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_JOINING    ");
+#endif // OLED
+		break;
+	case EV_JOINED:
+		Serial.println (F ("EV_JOINED"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_JOINED     ");
+#endif // OLED
+		break;
+	case EV_RFU1:
+		Serial.println (F ("EV_RFU1"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_RFUI");
+#endif // OLED
+		break;
+	case EV_JOIN_FAILED:
+		Serial.println (F ("EV_JOIN_FAILED"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_JOIN_FAILED");
+#endif // OLED
+		break;
+	case EV_REJOIN_FAILED:
+		Serial.println (F ("EV_REJOIN_FAILED"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_REJOIN_FAILED");
+#endif // OLED
+		break;
+	case EV_TXCOMPLETE:
+		Serial.println (F ("EV_TXCOMPLETE (includes waiting for RX windows)"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_TXCOMPLETE");
+#endif // OLED
+		if (LMIC.txrxFlags & TXRX_ACK) {
+			Serial.println (F ("Received ack"));
+#if OLED == 1
+			u8x8.drawString (0, 7, "Received ACK");
+#endif // OLED
+		}
+		if (LMIC.dataLen) {
+			Serial.println (F ("Received "));
+			Serial.println (LMIC.dataLen);
+			Serial.println (F (" bytes of payload"));
+#if OLED == 1
+			u8x8.drawString (0, 6, "RX ");
+			u8x8.setCursor (4, 6);
+			u8x8.printf ("%i bytes", LMIC.dataLen);
+			u8x8.setCursor (0, 7);
+			u8x8.printf ("RSSI %d SNR %.1d", LMIC.rssi, LMIC.snr);
+#endif // OLED
+		}
+		// Schedule next transmission
+		os_setTimedCallback (&sendjob, os_getTime () + sec2osticks (TX_INTERVAL), do_send);
+		break;
+	case EV_LOST_TSYNC:
+		Serial.println (F ("EV_LOST_TSYNC"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_LOST_TSYNC");
+#endif // OLED
+		break;
+	case EV_RESET:
+		Serial.println (F ("EV_RESET"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_RESET");
+#endif // OLED
+		break;
+	case EV_RXCOMPLETE:
+		// data received in ping slot
+		Serial.println (F ("EV_RXCOMPLETE"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_RXCOMPLETE");
+#endif // OLED
+		break;
+	case EV_LINK_DEAD:
+		Serial.println (F ("EV_LINK_DEAD"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_LINK_DEAD");
+#endif // OLED
+		break;
+	case EV_LINK_ALIVE:
+		Serial.println (F ("EV_LINK_ALIVE"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "EV_LINK_ALIVE");
+#endif // OLED
+		break;
+	default:
+		Serial.println (F ("Unknown event"));
+#if OLED == 1
+		u8x8.setCursor (0, 7);
+		u8x8.printf ("UNKNOWN EVENT %d", ev);
+#endif // OLED
+		break;
+	}
+}
+
+void do_send (osjob_t* j) {
+	// Check if there is not a current TX/RX job running
+	if (LMIC.opmode & OP_TXRXPEND) {
+		Serial.println (F ("OP_TXRXPEND, not sending"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "OP_TXRXPEND, not sent");
+#endif // OLED
+	}
+	else {
+		// Prepare upstream data transmission at the next possible time.
+		LMIC_setTxData2 (1, mydata, sizeof (mydata) - 1, 0);
+		Serial.println (F ("Packet queued"));
+#if OLED == 1
+		u8x8.drawString (0, 7, "PACKET QUEUED");
+#endif // OLED
+	}
+	// Next TX is scheduled after TX_COMPLETE event.
+}
+
+void setup () {
+	Serial.begin (115200);
+	Serial.println (F ("Starting"));
+#if OLED == 1
+	u8x8.begin ();
+	u8x8.setFont (u8x8_font_chroma48medium8_r);
+	u8x8.drawString (0, 1, "LoRaWAN LMiC");
+#endif // OLED
+
+#ifdef VCC_ENABLE
+	// For Pinoccio Scout boards
+	pinMode (VCC_ENABLE, OUTPUT);
+	digitalWrite (VCC_ENABLE, HIGH);
+	delay (1000);
+#endif
+
+	// LMIC init
+	os_init ();
+	// Reset the MAC state. Session and pending data transfers will be discarded.
+	LMIC_reset ();
+
+	// Set static session parameters. Instead of dynamically establishing a session
+	// by joining the network, precomputed session parameters are be provided.
+#ifdef PROGMEM
+// On AVR, these values are stored in flash and only copied to RAM
+// once. Copy them to a temporary buffer here, LMIC_setSession will
+// copy them into a buffer of its own again.
+	uint8_t appskey[sizeof (APPSKEY)];
+	uint8_t nwkskey[sizeof (NWKSKEY)];
+	memcpy_P (appskey, APPSKEY, sizeof (APPSKEY));
+	memcpy_P (nwkskey, NWKSKEY, sizeof (NWKSKEY));
+	LMIC_setSession (0x13, DEVADDR, nwkskey, appskey);
+#else
+// If not running an AVR with PROGMEM, just use the arrays directly
+	LMIC_setSession (0x13, DEVADDR, NWKSKEY, APPSKEY);
+#endif
+
+#if defined(CFG_eu868)
+	// Set up the channels used by the Things Network, which corresponds
+	// to the defaults of most gateways. Without this, only three base
+	// channels from the LoRaWAN specification are used, which certainly
+	// works, so it is good for debugging, but can overload those
+	// frequencies, so be sure to configure the full frequency range of
+	// your network here (unless your network autoconfigures them).
+	// Setting up channels should happen after LMIC_setSession, as that
+	// configures the minimal channel set.
+#if SINGLE_CHANNEL == 1
+	LMIC_setupChannel (0, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (1, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (2, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (3, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (4, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (5, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (6, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (7, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (8, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g2-band
+#else
+	LMIC_setupChannel(0, 868100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(1, 868300000, DR_RANGE_MAP(DR_SF12, DR_SF7B), BAND_CENTI);      // g-band
+	LMIC_setupChannel(2, 868500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(3, 867100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(4, 867300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(5, 867500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(6, 867700000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(7, 867900000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+	LMIC_setupChannel(8, 868800000, DR_RANGE_MAP(DR_FSK,  DR_FSK),  BAND_MILLI);      // g2-band
+	// TTN defines an additional channel at 869.525Mhz using SF9 for class B
+	// devices' ping slots. LMIC does not have an easy way to define set this
+	// frequency and support for class B is spotty and untested, so this
+	// frequency is not configured here.
+#endif //SINGLE_CHANNEL
+#elif defined(CFG_us915)
+	// NA-US channels 0-71 are configured automatically
+	// but only one group of 8 should (a subband) should be active
+	// TTN recommends the second sub band, 1 in a zero based count.
+	// https://github.com/TheThingsNetwork/gateway-conf/blob/master/US-global_conf.json
+	LMIC_selectSubBand (1);
+#endif
+
+	// Disable link check validation
+	LMIC_setLinkCheckMode (0);
+
+	// TTN uses SF9 for its RX2 window.
+	LMIC.dn2Dr = DR_SF9;
+
+	// Set data rate and transmit power for uplink (note: txpow seems to be ignored by the library)
+	LMIC_setDrTxpow (DR_SF7, 14);
+
+	// Start job
+	do_send (&sendjob);
+}
+
+void loop () {
+	os_runloop_once ();
+}

--- a/Nodo/TTGO_ESP32_v1/ttn-otaa/ttn-otaa.ino
+++ b/Nodo/TTGO_ESP32_v1/ttn-otaa/ttn-otaa.ino
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Thomas Telkamp and Matthijs Kooijman
+ *
+ * Permission is hereby granted, free of charge, to anyone
+ * obtaining a copy of this document and accompanying files,
+ * to do whatever they want with them without any restriction,
+ * including, but not limited to, copying, modification and redistribution.
+ * NO WARRANTY OF ANY KIND IS PROVIDED.
+ *
+ * This example sends a valid LoRaWAN packet with payload "Hello,
+ * world!", using frequency and encryption settings matching those of
+ * the The Things Network.
+ *
+ * This uses OTAA (Over-the-air activation), where where a DevEUI and
+ * application key is configured, which are used in an over-the-air
+ * activation procedure where a DevAddr and session keys are
+ * assigned/generated for use with all further communication.
+ *
+ * Note: LoRaWAN per sub-band duty-cycle limitation is enforced (1% in
+ * g1, 0.1% in g2), but not the TTN fair usage policy (which is probably
+ * violated by this sketch when left running for longer)!
+
+ * To use this sketch, first register your application and device with
+ * the things network, to set or generate an AppEUI, DevEUI and AppKey.
+ * Multiple devices can use the same AppEUI, but each device has its own
+ * DevEUI and AppKey.
+ *
+ * Do not forget to define the radio type correctly in config.h.
+ *
+ *******************************************************************************/
+
+#include <lmic.h>
+#include <hal/hal.h>
+#include <SPI.h>
+
+#define BUILTIN_LED 25
+
+#define OLED
+
+#ifdef OLED
+#include <U8x8lib.h>
+ // the OLED used
+U8X8_SSD1306_128X64_NONAME_SW_I2C u8x8 (/* clock=*/ 15, /* data=*/ 4, /* reset=*/ 16);
+#endif //OLED
+
+// This EUI must be in little-endian format, so least-significant-byte
+// first. When copying an EUI from ttnctl output, this means to reverse
+// the bytes. For TTN issued EUIs the last bytes should be 0xD5, 0xB3,
+// 0x70.
+static const u1_t PROGMEM APPEUI[8]= {0x8A, 0xF1, 0x00, 0xD0, 0x7E, 0xD5, 0xB3, 0x70};
+void os_getArtEui (u1_t* buf) { memcpy_P(buf, APPEUI, 8);}
+
+// This should also be in little endian format, see above.
+static const u1_t PROGMEM DEVEUI[8]= {0x63, 0x34, 0x2E, 0xD8, 0x7C, 0x92, 0x56, 0x00};
+void os_getDevEui (u1_t* buf) { memcpy_P(buf, DEVEUI, 8);}
+
+// This key should be in big endian format (or, since it is not really a
+// number but a block of memory, endianness does not really apply). In
+// practice, a key taken from ttnctl can be copied as-is.
+// The key shown here is the semtech default key.
+static const u1_t PROGMEM APPKEY[16] = {0xC3, 0x1F, 0xBF, 0x03, 0x33, 0x58, 0x89, 0x33, 0xB5, 0x8C, 0x5A, 0x21, 0x5A, 0x26, 0x77, 0xE3};
+void os_getDevKey (u1_t* buf) {  memcpy_P(buf, APPKEY, 16);}
+
+static uint8_t mydata[] = "Hello, world!";
+static osjob_t sendjob;
+
+// Schedule TX every this many seconds (might become longer due to duty
+// cycle limitations).
+const unsigned TX_INTERVAL = 60;
+
+// Pin mapping for TTGO ESP32 v1
+const lmic_pinmap lmic_pins = {
+	.nss = 18,
+	.rxtx = LMIC_UNUSED_PIN,
+	.rst = 14,
+	.dio = {/*dio0*/ 26, /*dio1*/ 33, /*dio2*/ 32}
+};
+
+void onEvent (ev_t ev) {
+    Serial.print(os_getTime());
+#ifdef OLED
+	u8x8.setCursor (0, 3);
+	u8x8.printf ("%0x", LMIC.devaddr);
+	u8x8.setCursor (0, 5);
+	u8x8.printf ("TIME %lu", os_getTime ());
+#endif //OLED
+	Serial.print(": ");
+    switch(ev) {
+        case EV_SCAN_TIMEOUT:
+            Serial.println(F("EV_SCAN_TIMEOUT"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_SCAN_TIMEOUT");
+#endif //OLED
+			break;
+        case EV_BEACON_FOUND:
+            Serial.println(F("EV_BEACON_FOUND"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_BEACON_FOUND");
+#endif //OLED
+			break;
+        case EV_BEACON_MISSED:
+            Serial.println(F("EV_BEACON_MISSED"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_BEACON_MISSED");
+#endif //OLED
+			break;
+        case EV_BEACON_TRACKED:
+            Serial.println(F("EV_BEACON_TRACKED"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_BEACON_TRACKED");
+#endif //OLED
+			break;
+        case EV_JOINING:
+            Serial.println(F("EV_JOINING"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_JOINING    ");
+#endif //OLED
+			break;
+        case EV_JOINED:
+            Serial.println(F("EV_JOINED"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_JOINED     ");
+#endif //OLED
+			{
+              u4_t netid = 0;
+              devaddr_t devaddr = 0;
+              u1_t nwkKey[16];
+              u1_t artKey[16];
+              LMIC_getSessionKeys(&netid, &devaddr, nwkKey, artKey);
+              Serial.print("netid: ");
+              Serial.println(netid, DEC);
+              Serial.print("devaddr: ");
+              Serial.println(devaddr, HEX);
+              Serial.print("artKey: ");
+              for (int i=0; i<sizeof(artKey); ++i) {
+                Serial.print(artKey[i], HEX);
+              }
+              Serial.println("");
+              Serial.print("nwkKey: ");
+              for (int i=0; i<sizeof(nwkKey); ++i) {
+                Serial.print(nwkKey[i], HEX);
+              }
+              Serial.println("");
+
+              LMIC_setSeqnoUp(140);
+            }
+            // Disable link check validation (automatically enabled
+            // during join, but not supported by TTN at this time).
+            LMIC_setLinkCheckMode(0);
+            break;
+        case EV_RFU1:
+            Serial.println(F("EV_RFU1"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_RFUI");
+#endif //OLED
+			break;
+        case EV_JOIN_FAILED:
+            Serial.println(F("EV_JOIN_FAILED"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_JOIN_FAILED");
+#endif //OLED
+			break;
+        case EV_REJOIN_FAILED:
+            Serial.println(F("EV_REJOIN_FAILED"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_REJOIN_FAILED");
+#endif //OLED
+			break;
+        case EV_TXCOMPLETE:
+            Serial.println(F("EV_TXCOMPLETE (includes waiting for RX windows)"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_TXCOMPLETE");
+#endif //OLED
+			if (LMIC.txrxFlags & TXRX_ACK) {
+				Serial.println (F ("Received ack"));
+#ifdef OLED
+				u8x8.drawString (0, 7, "Received ACK");
+#endif //OLED
+			}
+            if (LMIC.dataLen) {
+              Serial.print(F("Received "));
+              Serial.print(LMIC.dataLen);
+              Serial.println(F(" bytes of payload"));
+#ifdef OLED
+			  u8x8.drawString (0, 6, "RX ");
+			  u8x8.setCursor (4, 6);
+			  u8x8.printf ("%i bytes", LMIC.dataLen);
+			  u8x8.setCursor (0, 7);
+			  u8x8.printf ("RSSI %d SNR %.1d", LMIC.rssi, LMIC.snr);
+#endif //OLED
+			}
+            // Schedule next transmission
+            os_setTimedCallback(&sendjob, os_getTime()+sec2osticks(TX_INTERVAL), do_send);
+            break;
+        case EV_LOST_TSYNC:
+            Serial.println(F("EV_LOST_TSYNC"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_LOST_TSYNC");
+#endif //OLED
+			break;
+        case EV_RESET:
+            Serial.println(F("EV_RESET"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_RESET");
+#endif //OLED
+			break;
+        case EV_RXCOMPLETE:
+            // data received in ping slot
+            Serial.println(F("EV_RXCOMPLETE"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_RXCOMPLETE");
+#endif //OLED
+			break;
+        case EV_LINK_DEAD:
+            Serial.println(F("EV_LINK_DEAD"));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_LINK_DEAD");
+#endif //OLED
+			break;
+        case EV_LINK_ALIVE:
+            Serial.println(F("EV_LINK_ALIVE "+ev));
+#ifdef OLED
+			u8x8.drawString (0, 7, "EV_LINK_ALIVE");
+#endif //OLED
+			break;
+         default:
+            Serial.println(F("Unknown event"));
+#ifdef OLED
+			u8x8.printf ("UNKNOWN EVENT %d", ev);
+#endif //OLED
+			break;
+    }
+}
+
+void do_send(osjob_t* j){
+    // Check if there is not a current TX/RX job running
+    if (LMIC.opmode & OP_TXRXPEND) {
+        Serial.println(F("OP_TXRXPEND, not sending"));
+#ifdef OLED
+		u8x8.drawString (0, 7, "OP_TXRXPEND, not sent");
+#endif //OLED
+	} else {
+        // Prepare upstream data transmission at the next possible time.
+        LMIC_setTxData2(1, mydata, sizeof(mydata)-1, 0);
+        Serial.println(F("Packet queued"));
+#ifdef OLED
+		u8x8.drawString (0, 7, "PACKET QUEUED");
+#endif //OLED
+	}
+    // Next TX is scheduled after TX_COMPLETE event.
+}
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println(F("Starting"));
+
+#ifdef OLED
+	u8x8.begin ();
+	u8x8.setFont (u8x8_font_chroma48medium8_r);
+	u8x8.drawString (0, 1, "LoRaWAN LMiC");
+#endif //OLED
+
+    #ifdef VCC_ENABLE
+    // For Pinoccio Scout boards
+    pinMode(VCC_ENABLE, OUTPUT);
+    digitalWrite(VCC_ENABLE, HIGH);
+    delay(1000);
+    #endif
+
+    // LMIC init
+    os_init();
+    // Reset the MAC state. Session and pending data transfers will be discarded.
+    LMIC_reset();
+
+	//Not working yet. Using OTAA node tries to connect on several channels
+	LMIC_setupChannel (0, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (1, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (2, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (3, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (4, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (5, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (6, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (7, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g-band
+	LMIC_setupChannel (8, 868100000, DR_RANGE_MAP (DR_SF12, DR_SF7), BAND_CENTI);      // g2-band
+
+    // TTN uses SF9 for its RX2 window.
+	LMIC.dn2Dr = DR_SF9;
+
+	// Set data rate and transmit power for uplink (note: txpow seems to be ignored by the library)
+	LMIC_setDrTxpow (DR_SF7, 14);
+
+	    // Start job (sending automatically starts OTAA too)
+    do_send(&sendjob);
+}
+
+void loop() {
+    os_runloop_once();
+}


### PR DESCRIPTION
Añadido código para implementar gateway monocanal y nodo en la placa TTGO ESP32 v1. Para el nodo hay código con registro OTAA y ABP. En principio funcionan los dos pero el OTAA no está suficientemente probado.