### PR TITLE
Show IP in Serial Monitor

### DIFF
--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/.vscode/arduino.json
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/.vscode/arduino.json
@@ -1,0 +1,5 @@
+{
+    "sketch": "ESP-sc-gway.ino",
+    "board": "esp8266:esp8266:d1_mini",
+    "configuration": "CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600"
+}

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/ESP-sc-gway.ino
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/ESP-sc-gway.ino
@@ -1105,8 +1105,6 @@ void setup() {
   char MAC_char[19];								// XXX Unbelievable
   MAC_char[18] = 0;
 
-
-
   Serial.begin(_BAUDRATE);						// As fast as possible for bus
   delay(100);
   Serial.flush();
@@ -1168,6 +1166,11 @@ void setup() {
   Serial.print(F(" WiFi Connected to "));
   Serial.print(WiFi.SSID());
   Serial.println();
+
+  String MyIp =  String(WiFi.localIP()[0]) + "." + String(WiFi.localIP()[1]) + "." + String(WiFi.localIP()[2]) + "." + String(WiFi.localIP()[3]);
+  Serial.print(F("IP: "));
+  Serial.println(MyIp);
+
   delay(200);
 
   // If we are here we are connected to WLAN

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/_wwwServer.ino
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/_wwwServer.ino
@@ -1000,7 +1000,11 @@ void setupWWW()
 	// may take too much time to serve all information before a next
 	// package interrupt arrives at the gateway
 	
-	Serial.print(F("WWW Server started on port "));
+	String MyIp =  String(WiFi.localIP()[0]) + "." + String(WiFi.localIP()[1]) + "." + String(WiFi.localIP()[2]) + "." + String(WiFi.localIP()[3]);
+
+	Serial.print(F("WWW Server started at http://"));
+	Serial.print(MyIp);
+	Serial.print(F(":"));
 	Serial.println(A_SERVERPORT);
 	return;
 }

--- a/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/.vscode/arduino.json
+++ b/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/.vscode/arduino.json
@@ -1,0 +1,5 @@
+{
+    "sketch": "lora_mini_node_ttn_madrid_abp_puerta_abierta.ino",
+    "board": "MiniCore:avr:328",
+    "configuration": "bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external"
+}


### PR DESCRIPTION
With this change, the gateway will show it's IP address in Serial Monitor:
It allows the user to connect to the Gateway via the web interface.
![image](https://user-images.githubusercontent.com/333274/49341822-29466d80-f653-11e8-875b-972eb4ed1547.png)
