### PR TITLE
Replace arduino-mk with arduino-builder

### DIFF
--- a/Arduino.mk
+++ b/Arduino.mk
@@ -1,0 +1,43 @@
+#BOARD=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external
+#BOARD = esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600
+
+#LIBRARIES := ../libraries
+
+#--------
+# include this file in your sketch Makefile
+
+INO_FILE ?= $(shell basename $(CURDIR)).ino
+
+ARDUINO_IDE_VERSION ?= 1.8.6
+ARDUINO_DIR ?= $(HOME)/opt/arduino-$(ARDUINO_IDE_VERSION)
+BUILD_PATH ?= $(CURDIR)/.build
+CACHE_PATH ?= $(CURDIR)/.cache
+
+SOURCES := $(wildcard *.c *.cpp *.h *.ino *.pde)
+
+.DEFAULT_GOAL:=$(BUILD_PATH)/$(INO_FILE).elf
+
+$(BUILD_PATH)/$(INO_FILE).elf: $(SOURCES)
+	mkdir -p $(BUILD_PATH) $(CACHE_PATH)
+	$(ARDUINO_DIR)/arduino-builder \
+		-compile \
+		$(ARDUINO_BUILDER_OPT) \
+		-logger=human \
+		-build-path $(BUILD_PATH) --prefs=build.path=$(BUILD_PATH) \
+		-build-cache $(CACHE_PATH) \
+		-hardware $(ARDUINO_DIR)/hardware \
+		-hardware $(HOME)/.arduino15/packages \
+		-tools $(ARDUINO_DIR)/tools-builder \
+		-tools $(ARDUINO_DIR)/hardware/tools/avr \
+		-tools $(HOME)/.arduino15/packages \
+		-built-in-libraries $(ARDUINO_DIR)/libraries \
+		-libraries $(LIBRARIES) \
+		-fqbn=$(BOARD) \
+		-ide-version=10806 \
+		-prefs=build.warn_data_percentage=75 \
+		$(INO_FILE)
+
+clean:
+	rm -rf $(BUILD_PATH) $(CACHE_PATH)
+
+.PHONY: clean

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
@@ -1,10 +1,7 @@
 ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
-BUILD_DIR := /tmp/arduino_build_$(shell echo $$$$)
-CACHE_DIR := /tmp/arduino_cache_$(shell echo $$$$)
+INO_FILE := ESP-sc-gway.ino
 
 all:
-	rm -rf $(BUILD_DIR) $(CACHE_DIR) && \
-	mkdir -p $(BUILD_DIR) $(CACHE_DIR) && \
 	$(ARDUINO_DIR)/arduino-builder \
 		-compile \
 		-logger=human \
@@ -18,4 +15,4 @@ all:
 		-fqbn=esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600 \
 		-ide-version=10806 \
 		-verbose \
-		ESP-sc-gway.ino
+		$(INO_FILE)

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
@@ -14,5 +14,4 @@ all:
 		-libraries ../../libraries \
 		-fqbn=esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600 \
 		-ide-version=10806 \
-		-verbose \
 		$(INO_FILE)

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
@@ -12,6 +12,7 @@ all:
 		-tools $(HOME)/.arduino15/packages \
 		-built-in-libraries $(ARDUINO_DIR)/libraries \
 		-libraries ../../libraries \
+                -prefs=build.warn_data_percentage=75 \
 		-fqbn=esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600 \
 		-ide-version=10806 \
 		$(INO_FILE)

--- a/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
+++ b/Gateway/ESP-1ch-Gateway-v5.0.6-master-ttn-madrid/ESP-sc-gway/Makefile
@@ -1,18 +1,5 @@
-ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
-INO_FILE := ESP-sc-gway.ino
+BOARD = esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600
 
-all:
-	$(ARDUINO_DIR)/arduino-builder \
-		-compile \
-		-logger=human \
-		-hardware $(ARDUINO_DIR)/hardware \
-		-hardware $(HOME)/.arduino15/packages \
-		-tools $(ARDUINO_DIR)/tools-builder \
-		-tools $(ARDUINO_DIR)/hardware/tools/avr \
-		-tools $(HOME)/.arduino15/packages \
-		-built-in-libraries $(ARDUINO_DIR)/libraries \
-		-libraries ../../libraries \
-                -prefs=build.warn_data_percentage=75 \
-		-fqbn=esp8266:esp8266:d1_mini:CpuFrequency=80,VTable=flash,FlashSize=4M1M,LwIPVariant=v2mss536,Debug=Disabled,DebugLevel=None____,FlashErase=sdk,UploadSpeed=921600 \
-		-ide-version=10806 \
-		$(INO_FILE)
+LIBRARIES := ../../libraries
+
+include ../../../Arduino.mk

--- a/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
+++ b/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
@@ -16,5 +16,4 @@ all:
 		-ide-version=10806 \
 		-warnings=all \
 		-prefs=build.warn_data_percentage=75 \
-		-verbose \
 		$(INO_FILE)

--- a/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
+++ b/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
@@ -14,6 +14,5 @@ all:
 		-libraries ../libraries \
 		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
 		-ide-version=10806 \
-		-warnings=all \
 		-prefs=build.warn_data_percentage=75 \
 		$(INO_FILE)

--- a/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
+++ b/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
@@ -1,25 +1,20 @@
-USER_LIB_PATH:=$(realpath ../libraries)
+ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
+INO_FILE := lora_mini_node_ttn_madrid_abp_puerta_abierta.ino
 
-ARDUINO_LIBS=\
-  SPI\
-  IBM_LMIC_framework\
-  Low-Power
-
-ARDUINO_DIR:=$(HOME)/opt/arduino-$(ARDUINO_IDE_VERSION)
-ARDMK_DIR:=$(HOME)/opt/arduino-mk
-
-CORE = MiniCore
-ARCHITECTURE = avr
-BOARD_TAG = 328
-MCU=atmega328p
-F_CPU=8000000L
-HEX_MAXIMUM_SIZE=32256
-BOARD_VERSION=2.0.1
-
-ARDUINO_PLATFORM_LIB_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/libraries
-ARDUINO_CORE_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/cores/MCUdude_corefiles
-ARDUINO_VAR_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/variants
-VARIANT=standard
-
-
-include $(ARDMK_DIR)/Arduino.mk
+all:
+	$(ARDUINO_DIR)/arduino-builder \
+		-compile \
+		-logger=human \
+		-hardware $(ARDUINO_DIR)/hardware \
+		-hardware $(HOME)/.arduino15/packages \
+		-tools $(ARDUINO_DIR)/tools-builder \
+		-tools $(ARDUINO_DIR)/hardware/tools/avr \
+		-tools $(HOME)/.arduino15/packages \
+		-built-in-libraries $(ARDUINO_DIR)/libraries \
+		-libraries ../libraries \
+		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
+		-ide-version=10806 \
+		-warnings=all \
+		-prefs=build.warn_data_percentage=75 \
+		-verbose \
+		$(INO_FILE)

--- a/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
+++ b/Nodo/lora_mini_node_ttn_madrid_abp_puerta_abierta/Makefile
@@ -1,18 +1,5 @@
-ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
-INO_FILE := lora_mini_node_ttn_madrid_abp_puerta_abierta.ino
+BOARD=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external
 
-all:
-	$(ARDUINO_DIR)/arduino-builder \
-		-compile \
-		-logger=human \
-		-hardware $(ARDUINO_DIR)/hardware \
-		-hardware $(HOME)/.arduino15/packages \
-		-tools $(ARDUINO_DIR)/tools-builder \
-		-tools $(ARDUINO_DIR)/hardware/tools/avr \
-		-tools $(HOME)/.arduino15/packages \
-		-built-in-libraries $(ARDUINO_DIR)/libraries \
-		-libraries ../libraries \
-		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
-		-ide-version=10806 \
-		-prefs=build.warn_data_percentage=75 \
-		$(INO_FILE)
+LIBRARIES := ../libraries
+
+include ../../Arduino.mk

--- a/Nodo/ttnmapper_node/Makefile
+++ b/Nodo/ttnmapper_node/Makefile
@@ -16,5 +16,4 @@ all:
 		-ide-version=10806 \
 		-warnings=all \
 		-prefs=build.warn_data_percentage=75 \
-		-verbose \
 		$(INO_FILE)

--- a/Nodo/ttnmapper_node/Makefile
+++ b/Nodo/ttnmapper_node/Makefile
@@ -1,18 +1,5 @@
-ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
-INO_FILE := ttnmapper_node.ino
+BOARD=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external
 
-all:
-	$(ARDUINO_DIR)/arduino-builder \
-		-compile \
-		-logger=human \
-		-hardware $(ARDUINO_DIR)/hardware \
-		-hardware $(HOME)/.arduino15/packages \
-		-tools $(ARDUINO_DIR)/tools-builder \
-		-tools $(ARDUINO_DIR)/hardware/tools/avr \
-		-tools $(HOME)/.arduino15/packages \
-		-built-in-libraries $(ARDUINO_DIR)/libraries \
-		-libraries ../libraries \
-		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
-		-ide-version=10806 \
-		-prefs=build.warn_data_percentage=75 \
-		$(INO_FILE)
+LIBRARIES := ../libraries
+
+include ../../Arduino.mk

--- a/Nodo/ttnmapper_node/Makefile
+++ b/Nodo/ttnmapper_node/Makefile
@@ -14,6 +14,5 @@ all:
 		-libraries ../libraries \
 		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
 		-ide-version=10806 \
-		-warnings=all \
 		-prefs=build.warn_data_percentage=75 \
 		$(INO_FILE)

--- a/Nodo/ttnmapper_node/Makefile
+++ b/Nodo/ttnmapper_node/Makefile
@@ -1,25 +1,20 @@
-USER_LIB_PATH:=$(realpath ../libraries)
+ARDUINO_DIR := $(HOME)/opt/arduino-1.8.6
+INO_FILE := ttnmapper_node.ino
 
-ARDUINO_LIBS=\
-  SPI\
-  IBM_LMIC_framework\
-  Low-Power
-
-ARDUINO_DIR:=$(HOME)/opt/arduino-$(ARDUINO_IDE_VERSION)
-ARDMK_DIR:=$(HOME)/opt/arduino-mk
-
-CORE = MiniCore
-ARCHITECTURE = avr
-BOARD_TAG = 328
-MCU=atmega328p
-F_CPU=8000000L
-HEX_MAXIMUM_SIZE=32256
-BOARD_VERSION=2.0.1
-
-ARDUINO_PLATFORM_LIB_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/libraries
-ARDUINO_CORE_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/cores/MCUdude_corefiles
-ARDUINO_VAR_PATH:=$(HOME)/.arduino15/packages/$(CORE)/hardware/$(ARCHITECTURE)/$(BOARD_VERSION)/variants
-VARIANT=standard
-
-
-include $(ARDMK_DIR)/Arduino.mk
+all:
+	$(ARDUINO_DIR)/arduino-builder \
+		-compile \
+		-logger=human \
+		-hardware $(ARDUINO_DIR)/hardware \
+		-hardware $(HOME)/.arduino15/packages \
+		-tools $(ARDUINO_DIR)/tools-builder \
+		-tools $(ARDUINO_DIR)/hardware/tools/avr \
+		-tools $(HOME)/.arduino15/packages \
+		-built-in-libraries $(ARDUINO_DIR)/libraries \
+		-libraries ../libraries \
+		-fqbn=MiniCore:avr:328:bootloader=true,variant=modelP,BOD=1v8,LTO=Os,clock=8MHz_external \
+		-ide-version=10806 \
+		-warnings=all \
+		-prefs=build.warn_data_percentage=75 \
+		-verbose \
+		$(INO_FILE)

--- a/install_env.sh
+++ b/install_env.sh
@@ -1,6 +1,5 @@
 ## This script installs:
 #  - Arduino IDE
-#  - arduino-mk
 #  - Additional boards
 #  Inspired from: https://github.com/adafruit/travis-ci-arduino
 ##
@@ -13,7 +12,6 @@ then
 fi
 
 ARDUINO_DIR=${HOME}/opt/arduino-${ARDUINO_IDE_VERSION}
-ARDMK_DIR=${HOME}/opt/arduino-mk
 
 # if not already cached, download and install arduino IDE
 [ -d ${ARDUINO_DIR} ] || mkdir -p ${ARDUINO_DIR}
@@ -30,14 +28,7 @@ else
    echo "CACHED"
 fi
 
-cd
-echo "Arduino-mk:"
-git clone https://github.com/sudar/Arduino-Makefile.git ${ARDMK_DIR} || true
-cd ${ARDMK_DIR}
-git pull # cache needs update?
-cd
-
-export PATH="${ARDUINO_DIR}:${ARDMK_DIR}/bin:$PATH"
+export PATH="${ARDUINO_DIR}:$PATH"
 
 # make display available for arduino CLI
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
@@ -47,7 +38,6 @@ export DISPLAY=:1.0
 echo -e "\n########################################################################";
 echo -e "INSTALLING DEPENDENCIES"
 echo "########################################################################";
-
 
 # install the due, esp8266, and adafruit board packages
 echo "ADD BOARDS PACKAGES INDEX:"


### PR DESCRIPTION
Quito la dependencia de arduino-mk, y paso a usar arduino-builder (linea de comando de Arduino)
Añado Makefiles  y un Arduino.mk comun en la raiz al que los Makefiles llaman.